### PR TITLE
fix: queue concurrent permission requests to prevent silent cancellations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "vscode-acp" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.3] - 2026-02-24
+
+### Fixed
+- Queued concurrent permission requests so multiple prompts no longer clobber each other's QuickPick dialogs, which was silently cancelling approvals and causing repeated trust prompts
+
 ## [0.1.2] - 2026-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to the "vscode-acp" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [0.1.3] - 2026-02-24
+## [0.1.3] - 2026-03-01
 
-### Fixed
-- Queued concurrent permission requests so multiple prompts no longer clobber each other's QuickPick dialogs, which was silently cancelling approvals and causing repeated trust prompts
+### Added
+- **OpenClaw**: Added OpenClaw as a pre-configured agent (`npx openclaw acp`)
 
 ## [0.1.2] - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "vscode-acp" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.4]
+
+### Fixed
+- Queued concurrent permission requests so multiple prompts no longer clobber each other’s QuickPick dialogs, which was silently cancelling approvals and causing repeated trust prompts
+
 ## [0.1.3] - 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [Visual Studio Code extension](https://marketplace.visualstudio.com/items?item
 
 ## Features
 
-- **Multi-Agent Support**: Connect to 8 pre-configured ACP agents or add your own
+- **Multi-Agent Support**: Connect to 9 pre-configured ACP agents or add your own
 - **Single-Agent Focus**: One agent active at a time — seamlessly switch between agents
 - **Interactive Chat**: Built-in chat panel with Markdown rendering, inline tool call display, and collapsible tool sections
 - **Thinking Display**: See agent reasoning in a collapsible block with streaming animation and elapsed time
@@ -46,6 +46,7 @@ The extension comes with default configurations for:
 | Qoder CLI | `npx @qoder-ai/qodercli@latest --acp` |
 | Codex CLI | `npx @zed-industries/codex-acp@latest` |
 | OpenCode | `npx opencode-ai@latest acp` |
+| OpenClaw | `npx openclaw acp` |
 
 You can add custom agent configurations in settings.
 
@@ -53,7 +54,7 @@ You can add custom agent configurations in settings.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `acp.agents` | *(8 agents)* | Agent configurations. Each key is the agent name, value has `command`, `args`, and `env`. |
+| `acp.agents` | *(9 agents)* | Agent configurations. Each key is the agent name, value has `command`, `args`, and `env`. |
 | `acp.autoApprovePermissions` | `ask` | How agent permission requests are handled: `ask` or `allowAll`. |
 | `acp.defaultWorkingDirectory` | `""` | Default working directory for agent sessions. Empty uses current workspace. |
 | `acp.logTraffic` | `true` | Log all ACP protocol traffic to the ACP Traffic output channel. |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All commands are accessible via the Command Palette (`Ctrl+Shift+P`):
 ### Setup
 
 ```bash
-git clone https://github.com/your-username/vscode-acp.git
+git clone https://github.com/formulahendry/vscode-acp.git
 cd vscode-acp
 npm install
 ```
@@ -147,7 +147,7 @@ Communication with agents uses the ACP protocol (JSON-RPC 2.0 over stdio).
 
 - [ACP Client on Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client)
 - [Agent Client Protocol](https://agentclientprotocol.com/)
-- [GitHub Repository](https://github.com/nicepkg/vscode-acp)
+- [GitHub Repository](https://github.com/formulahendry/vscode-acp)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acp-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acp-client",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acp-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acp-client",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
@@ -1218,7 +1218,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2048,7 +2047,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2095,7 +2093,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2403,7 +2400,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3424,7 +3420,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7510,7 +7505,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7579,8 +7573,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7650,7 +7643,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7861,7 +7853,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7911,7 +7902,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "acp-client",
   "displayName": "ACP Client",
   "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, OpenClaw, and any ACP-compatible AI coding agent",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "formulahendry",
   "license": "MIT",
   "icon": "resources/icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "acp-client",
   "displayName": "ACP Client",
   "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, and any ACP-compatible AI coding agent",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "formulahendry",
   "license": "MIT",
   "icon": "resources/icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "acp-client",
   "displayName": "ACP Client",
   "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, OpenClaw, and any ACP-compatible AI coding agent",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "formulahendry",
   "license": "MIT",
   "icon": "resources/icon.png",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "acp-client",
   "displayName": "ACP Client",
-  "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, and any ACP-compatible AI coding agent",
-  "version": "0.1.3",
+  "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, OpenClaw, and any ACP-compatible AI coding agent",
+  "version": "0.1.2",
   "publisher": "formulahendry",
   "license": "MIT",
   "icon": "resources/icon.png",
@@ -289,6 +289,14 @@
               "command": "npx",
               "args": [
                 "opencode-ai@latest",
+                "acp"
+              ],
+              "env": {}
+            },
+            "OpenClaw": {
+              "command": "npx",
+              "args": [
+                "openclaw",
                 "acp"
               ],
               "env": {}

--- a/src/core/AgentManager.ts
+++ b/src/core/AgentManager.ts
@@ -97,7 +97,8 @@ export class AgentManager extends EventEmitter {
       const shellArgs = useLoginFlag ? ['-l', '-c', commandStr] : ['-c', commandStr];
 
       log(`Using shell: ${shell} ${shellArgs.join(' ')}`);
-      sendEvent('agent/spawn/shell', { shell, useLoginFlag: String(useLoginFlag) });
+      const shellName = shell.split('/').pop() || shell;
+      sendEvent('agent/spawn/shell', { shell: shellName, useLoginFlag: String(useLoginFlag) });
       return spawn(shell, shellArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env, ...(config.env || {}) },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,18 +222,15 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  // Show Logs
-  const showLogsCmd = vscode.commands.registerCommand('acp.showLogs', () => {
-    getOutputChannel().show();
-  });
-
   // Show Log
   const showLogCmd = vscode.commands.registerCommand('acp.showLog', () => {
+    sendEvent('command/showLog');
     getOutputChannel().show();
   });
 
   // Show Traffic
   const showTrafficCmd = vscode.commands.registerCommand('acp.showTraffic', () => {
+    sendEvent('command/showTraffic');
     getTrafficChannel().show();
   });
 
@@ -394,7 +391,6 @@ export function activate(context: vscode.ExtensionContext): void {
     sendPromptCmd,
     cancelTurnCmd,
     restartAgentCmd,
-    showLogsCmd,
     showLogCmd,
     showTrafficCmd,
     setModeCmd,

--- a/src/handlers/PermissionHandler.ts
+++ b/src/handlers/PermissionHandler.ts
@@ -18,7 +18,7 @@ export class PermissionHandler {
       () => undefined,
       () => undefined,
     );
-    return result;
+    return result.catch(() => ({ outcome: { outcome: 'cancelled' as const } }));
   }
 
   private async handlePermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {

--- a/src/handlers/PermissionHandler.ts
+++ b/src/handlers/PermissionHandler.ts
@@ -7,9 +7,18 @@ import type { RequestPermissionRequest, RequestPermissionResponse } from '@agent
 /**
  * Handles ACP permission requests from agents.
  * Shows VS Code QuickPick for user to select from agent-provided options.
+ * Requests are queued so concurrent permission prompts don't clobber each other.
  */
 export class PermissionHandler {
+  private queue: Promise<RequestPermissionResponse> = Promise.resolve({ outcome: { outcome: 'cancelled' } });
+
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+    const result = this.queue.then(() => this.handlePermission(params));
+    this.queue = result.catch(() => ({ outcome: { outcome: 'cancelled' as const } }));
+    return result;
+  }
+
+  private async handlePermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
     const config = vscode.workspace.getConfiguration('acp');
     const autoApprove = config.get<string>('autoApprovePermissions', 'none');
 

--- a/src/handlers/PermissionHandler.ts
+++ b/src/handlers/PermissionHandler.ts
@@ -10,11 +10,14 @@ import type { RequestPermissionRequest, RequestPermissionResponse } from '@agent
  * Requests are queued so concurrent permission prompts don't clobber each other.
  */
 export class PermissionHandler {
-  private queue: Promise<RequestPermissionResponse> = Promise.resolve({ outcome: { outcome: 'cancelled' } });
+  private queue: Promise<void> = Promise.resolve();
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
     const result = this.queue.then(() => this.handlePermission(params));
-    this.queue = result.catch(() => ({ outcome: { outcome: 'cancelled' as const } }));
+    this.queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
     return result;
   }
 

--- a/src/handlers/PermissionHandler.ts
+++ b/src/handlers/PermissionHandler.ts
@@ -14,11 +14,12 @@ export class PermissionHandler {
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
     const result = this.queue.then(() => this.handlePermission(params));
-    this.queue = result.then(
-      () => undefined,
-      () => undefined,
-    );
-    return result.catch(() => ({ outcome: { outcome: 'cancelled' as const } }));
+    this.queue = result.then(() => {}, () => {});
+    return result.catch((err) => {
+      log(`Permission request failed: ${err}`);
+      sendEvent('permission/responded', { permissionType: params.toolCall?.title || 'Permission Request', outcome: 'error' });
+      return { outcome: { outcome: 'cancelled' as const } };
+    });
   }
 
   private async handlePermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {


### PR DESCRIPTION
I threw together a quick PR after hitting issues with multiple concurrent tool calls breaking the permission prompting. No issue if you throw this out, and do your own thing, but this seems to have fixed the bug for me locally, so I turned it into a PR. More detail below.

## Problem

When multiple permission requests arrive simultaneously (e.g. parallel file reads + terminal command), each `showQuickPick` call dismisses the previous one, causing it to silently return `undefined` (treated as `cancelled`). The agent sees the tool call as rejected and re-asks on the next prompt, creating a loop where the user keeps approving but nothing executes.

## Fix

Added a serial promise queue to `PermissionHandler` so concurrent `requestPermission` calls are processed one at a time. Each QuickPick waits for the previous one to resolve before showing.

## Changes

- `src/handlers/PermissionHandler.ts` — Added `queue` field, extracted logic into private `handlePermission`
- `CHANGELOG.md` — Added 0.1.3 entry
- `package.json` — Version bump to 0.1.3