### PR TITLE
fix: use workspace cwd for agent spawn and session

### DIFF
--- a/src/core/AgentManager.ts
+++ b/src/core/AgentManager.ts
@@ -75,7 +75,7 @@ export class AgentManager extends EventEmitter {
   /**
    * Spawn an agent as a child process with stdin/stdout piped.
    */
-  spawnAgent(name: string, config: AgentConfigEntry): AgentInstance {
+  spawnAgent(name: string, config: AgentConfigEntry, cwd?: string): AgentInstance {
     const id = `agent_${this.nextId++}`;
     log(`Spawning agent "${name}" (${id}): ${config.command} ${(config.args || []).join(' ')}`);
 
@@ -86,6 +86,7 @@ export class AgentManager extends EventEmitter {
         return spawn(config.command, config.args || [], {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: { ...process.env, ...(config.env || {}) },
+          cwd: cwd || undefined,
           shell: true,
         });
       }
@@ -102,6 +103,7 @@ export class AgentManager extends EventEmitter {
       return spawn(shell, shellArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env, ...(config.env || {}) },
+        cwd: cwd || undefined,
       });
     })();
 

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -48,7 +48,7 @@ export class SessionManager extends EventEmitter {
 
   private getWorkspaceCwd(): string {
     const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    return cwd || '/';
+    return cwd || process.cwd();
   }
 
   /**

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -46,6 +46,11 @@ export class SessionManager extends EventEmitter {
     super();
   }
 
+  private getWorkspaceCwd(): string {
+    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    return cwd || '/';
+  }
+
   /**
    * Connect to an agent and start chatting.
    * Only one agent can be connected at a time — automatically disconnects
@@ -78,8 +83,10 @@ export class SessionManager extends EventEmitter {
     const connectStartTime = Date.now();
 
     try {
-      // Spawn the agent process
-      const agentInstance = this.agentManager.spawnAgent(agentName, config);
+      const workspaceCwd = this.getWorkspaceCwd();
+
+      // Spawn the agent process in workspace cwd
+      const agentInstance = this.agentManager.spawnAgent(agentName, config, workspaceCwd);
       const agentId = agentInstance.id;
 
       // Listen for agent errors/close
@@ -123,7 +130,7 @@ export class SessionManager extends EventEmitter {
       }
 
       // Create ACP session (with auth handling)
-      const sessionInfo = await this.createAcpSession(agentName, agentId, connInfo);
+      const sessionInfo = await this.createAcpSession(agentName, agentId, connInfo, workspaceCwd);
 
       this.sessions.set(sessionInfo.sessionId, sessionInfo);
       this.agentSessions.set(agentName, sessionInfo.sessionId);
@@ -190,8 +197,8 @@ export class SessionManager extends EventEmitter {
     agentName: string,
     agentId: string,
     connInfo: ConnectionInfo,
+    cwd: string,
   ): Promise<SessionInfo> {
-    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
     let sessionResponse: NewSessionResponse;
     try {
       sessionResponse = await connInfo.connection.newSession({


### PR DESCRIPTION
## Background
In some environments, the agent process starts with `/` as its working directory, which causes:
- startup logs showing `cwd=/`
- behavior that is inconsistent with the current VS Code workspace

## Changes
- Unified working directory resolution in `SessionManager` (prefer current workspace root, fallback to `process.cwd()` when no workspace is open)
- When connecting to an agent, use the same `cwd` for both:
  - agent process spawn (added `AgentManager.spawnAgent(..., cwd)` and pass-through to `spawn`)
  - ACP `newSession` cwd argument
- Ensure both initial session creation and post-auth retry use the same `cwd`

## Scope
- `src/core/SessionManager.ts`
- `src/core/AgentManager.ts`

## Verification
- `npm run lint` passes
- `npm run compile` passes

## Expected Result
- Agent startup working directory matches the current workspace
- No unexpected fallback to `process.cwd()` when no workspace is open)