### PR TITLE
Add openHarness as a pre-configured agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The extension comes with default configurations for:
 | Codex CLI | `npx @zed-industries/codex-acp@latest` |
 | OpenCode | `npx opencode-ai@latest acp` |
 | OpenClaw | `npx openclaw acp` |
+| [openHarness](https://github.com/zhijiewong/openharness) | `npx @zhijiewang/openharness@latest acp` |
 | [Kiro CLI](https://kiro.dev/docs/cli/acp/) | `kiro-cli acp` |
 | [Hermes Agent](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp) | `hermes acp` |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acp-client",
   "displayName": "ACP Client",
-  "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, OpenClaw, Kiro CLI, Hermes Agent, and any ACP-compatible AI coding agent",
+  "description": "Agent Client Protocol client for VS Code — connect to GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, Codex CLI, OpenCode, OpenClaw, openHarness, Kiro CLI, Hermes Agent, and any ACP-compatible AI coding agent",
   "version": "0.2.0",
   "publisher": "formulahendry",
   "license": "MIT",
@@ -350,6 +350,14 @@
               "command": "npx",
               "args": [
                 "openclaw",
+                "acp"
+              ],
+              "env": {}
+            },
+            "openHarness": {
+              "command": "npx",
+              "args": [
+                "@zhijiewang/openharness@latest",
                 "acp"
               ],
               "env": {}


### PR DESCRIPTION
This PR adds [openHarness](https://github.com/zhijiewong/openharness) to the `acp.agents` defaults, alongside Claude Code / Gemini CLI / Codex CLI / OpenCode / etc.

## What's openHarness?

An open-source terminal coding agent that speaks ACP natively via `oh acp` — no adapter package required. It works with any LLM provider (Anthropic, OpenAI, Ollama, llama.cpp, LM Studio, OpenRouter) and ships its own permission flow, cost tracking, session persistence, MCP support, hooks, skills, and 80+ slash commands.

## Why this entry works out of the box with vscode-acp

The OH side just shipped four ACP-server gaps (v2.44 → v2.47, merged in [zhijiewong/openharness#133](https://github.com/zhijiewong/openharness/pull/133)) specifically so this PR could land with full parity to the existing agents:

| ACP method | OH support |
|---|---|
| `session/request_permission` | Round-trip with allow_once / allow_always / reject_once / reject_always |
| `usage_update` | Cumulative cost + context window after every model call |
| `session/update` (rate_limited notice) | Italicized message + structured `_meta` retry hint |
| `session/load` capability | Resume by sessionId, restores prior message history |

That means vscode-acp's existing permission dialogs, cost surface, rate-limit indicator, and session-resume UI all light up immediately when a user picks openHarness — no client-side changes needed.

## What changes

- `package.json` — adds `openHarness` to `contributes.configuration.properties.acp.agents.default` (between `OpenClaw` and `Kiro CLI`). Standard `npx <package>@latest acp` shape, matching `OpenCode` and `OpenClaw`. Updates the top-level `description` to mention the new agent.
- `README.md` — adds a row to the "Pre-configured Agents" table, linked to the openHarness repo.

No source code changes, no new dependencies, no behavioral changes to existing agents.

## Test plan

- [x] package.json is valid JSON (verified with `node -e \"require('./package.json')\"`)
- [x] `openHarness` entry follows the same shape as `OpenCode` and `OpenClaw` (closest precedents — both also dispatch to a package's `acp` subcommand)
- [ ] (reviewer): install the extension, pick `openHarness`, run a prompt — confirm session/update + permission dialogs work

The `npx @zhijiewang/openharness@latest acp` command auto-downloads the package on first use. Users with a global `oh` install can swap to `{ command: \"oh\", args: [\"acp\"] }` in their settings — both forms work.

Repo: https://github.com/zhijiewong/openharness (MIT)
npm: https://www.npmjs.com/package/@zhijiewang/openharness

Happy to address any feedback — thank you for maintaining vscode-acp!