### PR TITLE
feat: add Reasonix agent and edit diff previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "vscode-acp" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+### Added
+- Reasonix agent: `reasonix acp` (DeepSeek-native coding agent with cache-first loop).
+
 ## [0.2.0] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,6 +97,33 @@ All commands are accessible via the Command Palette (`Ctrl+Shift+P`):
 
 ## Development
 
+### Testing This Fork
+
+This branch is not published to the VS Code Marketplace. To test it, build and
+install a VSIX from this fork:
+
+```bash
+git clone https://github.com/yes999zc/vscode-acp.git
+cd vscode-acp
+git checkout add-reasonix-agent
+npm install
+npx vsce package --out acp-client-local.vsix
+code --install-extension acp-client-local.vsix --force
+```
+
+After installation, reload VS Code with `Developer: Reload Window`.
+
+To test Reasonix, make sure `reasonix` is installed and available on the PATH
+seen by VS Code:
+
+```bash
+reasonix --version
+```
+
+Then open the ACP Client panel, connect to `Reasonix`, and try a code-editing
+prompt. The extension should show tool calls in chat, follow edited files, and
+open a diff after edits complete.
+
 ### Prerequisites
 
 - Node.js 18+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The extension comes with default configurations for:
 | Claude Code | `npx @agentclientprotocol/claude-agent-acp@latest` |
 | Gemini CLI | `npx @google/gemini-cli@latest --experimental-acp` |
 | Qwen Code | `npx @qwen-code/qwen-code@latest --acp --experimental-skills` |
+| [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `reasonix acp` |
 | Auggie CLI | `npx @augmentcode/auggie@latest --acp` |
 | Qoder CLI | `npx @qoder-ai/qodercli@latest --acp` |
 | Codex CLI | `npx @zed-industries/codex-acp@latest` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,7 +1218,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2048,7 +2047,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2095,7 +2093,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2403,7 +2400,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3424,7 +3420,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7510,7 +7505,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7579,8 +7573,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7650,7 +7643,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7861,7 +7853,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7911,7 +7902,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -313,6 +313,11 @@
               ],
               "env": {}
             },
+            "Reasonix": {
+              "command": "reasonix",
+              "args": ["acp"],
+              "env": {}
+            },
             "Auggie CLI": {
               "command": "npx",
               "args": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { ConnectionManager } from './core/ConnectionManager';
 import { SessionManager } from './core/SessionManager';
 import { SessionHistoryStore } from './core/SessionHistoryStore';
 import { SessionUpdateHandler } from './handlers/SessionUpdateHandler';
+import { DiffPreviewHandler } from './handlers/DiffPreviewHandler';
 import { SessionTreeProvider } from './ui/SessionTreeProvider';
 import { StatusBarManager } from './ui/StatusBarManager';
 import { ChatWebviewProvider } from './ui/ChatWebviewProvider';
@@ -22,6 +23,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // --- Core services ---
   const sessionUpdateHandler = new SessionUpdateHandler();
+  const diffPreviewHandler = new DiffPreviewHandler();
+  sessionUpdateHandler.addListener(diffPreviewHandler.listener);
   const agentManager = new AgentManager();
   const connectionManager = new ConnectionManager(sessionUpdateHandler);
   const sessionManager = new SessionManager(
@@ -522,6 +525,7 @@ export function activate(context: vscode.ExtensionContext): void {
     {
       dispose: () => {
         sessionManager.dispose();
+        diffPreviewHandler.dispose();
         sessionUpdateHandler.dispose();
         chatWebviewProvider.dispose();
         sessionTreeProvider.dispose();

--- a/src/handlers/DiffPreviewHandler.ts
+++ b/src/handlers/DiffPreviewHandler.ts
@@ -3,6 +3,17 @@ import * as path from 'path';
 import * as os from 'os';
 import { SessionUpdateListener } from './SessionUpdateHandler';
 import type { SessionNotification } from '@agentclientprotocol/sdk';
+import { logError } from '../utils/Logger';
+
+interface ActiveToolCall {
+  toolCallId: string;
+  kind?: string | null;
+  title?: string | null;
+  status?: string | null;
+  locations?: Array<{ path: string; line?: number | null }> | null;
+  content?: Array<any> | null;
+  rawInput?: unknown;
+}
 
 /**
  * Shows a diff view when an agent edits files through tool calls.
@@ -14,6 +25,15 @@ import type { SessionNotification } from '@agentclientprotocol/sdk';
  */
 export class DiffPreviewHandler {
   private pendingWrites = new Map<string, string>(); // absPath → oldContent
+  private activeToolCalls = new Map<string, ActiveToolCall>();
+  private highlightedToolCalls = new Set<string>();
+
+  private readonly editDecoration = vscode.window.createTextEditorDecorationType({
+    isWholeLine: true,
+    backgroundColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
+    overviewRulerColor: new vscode.ThemeColor('editorOverviewRuler.findMatchForeground'),
+    overviewRulerLane: vscode.OverviewRulerLane.Right,
+  });
 
   readonly listener: SessionUpdateListener;
 
@@ -24,36 +44,125 @@ export class DiffPreviewHandler {
   }
 
   private handleUpdate(update: SessionNotification): void {
-    const u = update as any;
-    if (u.sessionUpdate !== 'tool_call_update') { return; }
-    if (u.kind !== 'edit') { return; }
+    const u = (update as any).update;
+    if (!u || (u.sessionUpdate !== 'tool_call' && u.sessionUpdate !== 'tool_call_update')) { return; }
 
-    const filePath = this.extractFilePath(u);
-    if (!filePath) { return; }
+    const toolCall = this.mergeToolCallUpdate(u);
+    if (!this.isEditToolCall(toolCall)) { return; }
 
-    const status = u.status;
+    const filePaths = this.extractFilePaths(toolCall);
+    if (filePaths.length === 0) { return; }
+
+    const status = toolCall.status ?? (u.sessionUpdate === 'tool_call' ? 'pending' : undefined);
     if (status === 'pending' || status === 'in_progress') {
-      this.cacheOldContent(filePath);
+      for (const filePath of filePaths) {
+        void this.cacheOldContent(filePath);
+      }
+      void this.showActiveEdit(toolCall, filePaths[0]);
     } else if (status === 'completed') {
+      this.clearToolCallDecoration(toolCall.toolCallId);
       // Small delay to let the filesystem settle
-      setTimeout(() => this.showDiff(filePath), 100);
+      for (const filePath of filePaths) {
+        setTimeout(() => this.showDiff(filePath), 100);
+      }
+      this.activeToolCalls.delete(toolCall.toolCallId);
+    } else if (status === 'failed') {
+      this.clearToolCallDecoration(toolCall.toolCallId);
+      this.activeToolCalls.delete(toolCall.toolCallId);
     }
   }
 
-  private extractFilePath(update: any): string | null {
+  private mergeToolCallUpdate(update: any): ActiveToolCall {
+    const toolCallId = update.toolCallId || 'unknown';
+    const previous: ActiveToolCall = this.activeToolCalls.get(toolCallId) ?? { toolCallId };
+    const merged: ActiveToolCall = {
+      ...previous,
+      ...update,
+      toolCallId,
+      kind: update.kind ?? previous.kind,
+      title: update.title ?? previous.title,
+      status: update.status ?? previous.status,
+      locations: update.locations ?? previous.locations,
+      content: update.content ?? previous.content,
+      rawInput: update.rawInput ?? previous.rawInput,
+    };
+    this.activeToolCalls.set(toolCallId, merged);
+    return merged;
+  }
+
+  private isEditToolCall(update: ActiveToolCall): boolean {
+    if (update.kind === 'edit') { return true; }
+    if (update.content?.some(item => item?.type === 'diff')) { return true; }
+
+    const title = update.title || '';
+    return /\b(write|edit|patch|modify|update|create|delete|move|rename)_?(file)?\b/i.test(title);
+  }
+
+  private extractFilePaths(update: ActiveToolCall): string[] {
+    const paths = new Set<string>();
+
     // Prefer locations array (most reliable)
     const locations = update.locations;
     if (locations && locations.length > 0) {
-      const p = locations[0].path || locations[0].uri?.path;
-      if (p) { return p; }
+      for (const location of locations) {
+        this.addPath(paths, location.path);
+      }
     }
+
+    for (const item of update.content ?? []) {
+      if (item?.type === 'diff') {
+        this.addPath(paths, item.path);
+      }
+    }
+
+    this.collectPathsFromValue(paths, update.rawInput);
 
     // Fall back to parsing title: "write_file /abs/path/to/file.ts"
     const title: string = update.title || '';
     const absMatch = title.match(/(?:\s|^)(\/[^\s]+)/);
-    if (absMatch) { return absMatch[1]; }
+    if (absMatch) { this.addPath(paths, absMatch[1]); }
 
-    return null;
+    return [...paths];
+  }
+
+  private addPath(paths: Set<string>, filePath: unknown): void {
+    if (typeof filePath !== 'string' || filePath.length === 0) { return; }
+    paths.add(this.normalizePath(filePath));
+  }
+
+  private normalizePath(filePath: string): string {
+    if (path.isAbsolute(filePath)) { return filePath; }
+
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    return path.resolve(workspacePath ?? process.cwd(), filePath);
+  }
+
+  private collectPathsFromValue(paths: Set<string>, value: unknown, depth = 0): void {
+    if (!value || depth > 3) { return; }
+
+    if (typeof value === 'string') {
+      if (path.isAbsolute(value)) {
+        this.addPath(paths, value);
+      }
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        this.collectPathsFromValue(paths, item, depth + 1);
+      }
+      return;
+    }
+
+    if (typeof value !== 'object') { return; }
+
+    for (const [key, item] of Object.entries(value)) {
+      if (/^(path|file|filePath|filepath|filename|targetPath|sourcePath)$/i.test(key)) {
+        this.addPath(paths, item);
+      } else {
+        this.collectPathsFromValue(paths, item, depth + 1);
+      }
+    }
   }
 
   private async cacheOldContent(absPath: string): Promise<void> {
@@ -106,14 +215,67 @@ export class DiffPreviewHandler {
         'vscode.diff',
         oldUri,
         uri,
-        `${path.basename(absPath)} (before → after)`
+        `${path.basename(absPath)} (before -> after)`
       );
     } catch {
       // File may have been deleted or become inaccessible — skip diff
     }
   }
 
+  private async showActiveEdit(toolCall: ActiveToolCall, absPath: string): Promise<void> {
+    try {
+      const uri = vscode.Uri.file(absPath);
+      const doc = await vscode.workspace.openTextDocument(uri);
+      await vscode.window.showTextDocument(doc, {
+        preview: true,
+        preserveFocus: true,
+      });
+
+      this.highlightedToolCalls.add(toolCall.toolCallId);
+      this.refreshDecorations();
+    } catch (e) {
+      logError(`Failed to show active edit: ${absPath}`, e);
+    }
+  }
+
+  private getDecorationRanges(toolCall: ActiveToolCall, doc: vscode.TextDocument): vscode.Range[] {
+    const lineNumbers = (toolCall.locations ?? [])
+      .filter(location => this.normalizePath(location.path) === doc.uri.fsPath && typeof location.line === 'number')
+      .map(location => Math.max(0, Math.min(doc.lineCount - 1, (location.line ?? 1) - 1)));
+
+    if (lineNumbers.length === 0) {
+      const lastLine = Math.max(0, doc.lineCount - 1);
+      return [new vscode.Range(0, 0, lastLine, doc.lineAt(lastLine).range.end.character)];
+    }
+
+    return lineNumbers.map(line => doc.lineAt(line).range);
+  }
+
+  private clearToolCallDecoration(toolCallId: string): void {
+    if (!this.highlightedToolCalls.has(toolCallId)) { return; }
+
+    this.highlightedToolCalls.delete(toolCallId);
+    this.refreshDecorations();
+  }
+
+  private refreshDecorations(): void {
+    for (const editor of vscode.window.visibleTextEditors) {
+      const ranges: vscode.Range[] = [];
+      for (const toolCallId of this.highlightedToolCalls) {
+        const toolCall = this.activeToolCalls.get(toolCallId);
+        if (toolCall && this.extractFilePaths(toolCall).includes(editor.document.uri.fsPath)) {
+          ranges.push(...this.getDecorationRanges(toolCall, editor.document));
+        }
+      }
+
+      editor.setDecorations(this.editDecoration, ranges);
+    }
+  }
+
   dispose(): void {
     this.pendingWrites.clear();
+    this.activeToolCalls.clear();
+    this.highlightedToolCalls.clear();
+    this.editDecoration.dispose();
   }
 }

--- a/src/handlers/DiffPreviewHandler.ts
+++ b/src/handlers/DiffPreviewHandler.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import { SessionUpdateListener } from './SessionUpdateHandler';
+import type { SessionNotification } from '@agentclientprotocol/sdk';
+
+/**
+ * Shows a diff view when an agent edits files through tool calls.
+ *
+ * Reasonix (and possibly other agents) writes files directly via Node.js fs
+ * rather than calling the ACP writeTextFile method. This handler intercepts
+ * session/update notifications for edit-kind tool calls, snapshots the old
+ * content before the write, and opens a vscode.diff view afterwards.
+ */
+export class DiffPreviewHandler {
+  private pendingWrites = new Map<string, string>(); // absPath → oldContent
+
+  readonly listener: SessionUpdateListener;
+
+  constructor() {
+    this.listener = (update: SessionNotification) => {
+      this.handleUpdate(update);
+    };
+  }
+
+  private handleUpdate(update: SessionNotification): void {
+    const u = update as any;
+    if (u.sessionUpdate !== 'tool_call_update') { return; }
+    if (u.kind !== 'edit') { return; }
+
+    const filePath = this.extractFilePath(u);
+    if (!filePath) { return; }
+
+    const status = u.status;
+    if (status === 'pending' || status === 'in_progress') {
+      this.cacheOldContent(filePath);
+    } else if (status === 'completed') {
+      // Small delay to let the filesystem settle
+      setTimeout(() => this.showDiff(filePath), 100);
+    }
+  }
+
+  private extractFilePath(update: any): string | null {
+    // Prefer locations array (most reliable)
+    const locations = update.locations;
+    if (locations && locations.length > 0) {
+      const p = locations[0].path || locations[0].uri?.path;
+      if (p) { return p; }
+    }
+
+    // Fall back to parsing title: "write_file /abs/path/to/file.ts"
+    const title: string = update.title || '';
+    const absMatch = title.match(/(?:\s|^)(\/[^\s]+)/);
+    if (absMatch) { return absMatch[1]; }
+
+    return null;
+  }
+
+  private async cacheOldContent(absPath: string): Promise<void> {
+    if (this.pendingWrites.has(absPath)) { return; }
+
+    const uri = vscode.Uri.file(absPath);
+
+    // Prefer open editor content (may have unsaved changes)
+    const openDoc = vscode.workspace.textDocuments.find(
+      doc => doc.uri.fsPath === uri.fsPath
+    );
+    if (openDoc) {
+      this.pendingWrites.set(absPath, openDoc.getText());
+      return;
+    }
+
+    // Read from disk — best-effort, may lose a race with the agent's write
+    try {
+      const raw = await vscode.workspace.fs.readFile(uri);
+      this.pendingWrites.set(absPath, Buffer.from(raw).toString('utf-8'));
+    } catch {
+      // File doesn't exist yet (new file) — no diff needed
+    }
+  }
+
+  private async showDiff(absPath: string): Promise<void> {
+    const oldContent = this.pendingWrites.get(absPath);
+    this.pendingWrites.delete(absPath);
+
+    try {
+      const uri = vscode.Uri.file(absPath);
+      const raw = await vscode.workspace.fs.readFile(uri);
+      const newContent = Buffer.from(raw).toString('utf-8');
+
+      if (oldContent === undefined) {
+        // New file — open in editor
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc, { preview: true, preserveFocus: true });
+        return;
+      }
+
+      if (oldContent === newContent) { return; }
+
+      const tmpDir = path.join(os.tmpdir(), 'vscode-acp-diffs');
+      await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpDir));
+      const oldUri = vscode.Uri.file(path.join(tmpDir, path.basename(absPath)));
+      await vscode.workspace.fs.writeFile(oldUri, Buffer.from(oldContent, 'utf-8'));
+
+      await vscode.commands.executeCommand(
+        'vscode.diff',
+        oldUri,
+        uri,
+        `${path.basename(absPath)} (before → after)`
+      );
+    } catch {
+      // File may have been deleted or become inaccessible — skip diff
+    }
+  }
+
+  dispose(): void {
+    this.pendingWrites.clear();
+  }
+}

--- a/src/handlers/FileSystemHandler.ts
+++ b/src/handlers/FileSystemHandler.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
 import { log, logError } from '../utils/Logger';
 
 import type {
@@ -56,20 +58,48 @@ export class FileSystemHandler {
 
   /**
    * Write a text file. Creates parent directories if needed.
-   * Opens the file in the editor so the user can see changes.
+   * Shows a diff view for existing files so the user can review changes.
    */
   async writeTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
     log(`writeTextFile: ${params.path}`);
 
     try {
       const uri = vscode.Uri.file(params.path);
-      const encoded = Buffer.from(params.content, 'utf-8');
+      const newContent = params.content;
+      const encoded = Buffer.from(newContent, 'utf-8');
+
+      // Read old content (if file exists) before overwriting
+      let oldContent: string | null = null;
+      try {
+        const oldRaw = await vscode.workspace.fs.readFile(uri);
+        oldContent = Buffer.from(oldRaw).toString('utf-8');
+      } catch {
+        // File doesn't exist yet — no diff needed
+      }
 
       await vscode.workspace.fs.writeFile(uri, encoded);
 
-      // Open the file in the editor so the user sees the change
-      const doc = await vscode.workspace.openTextDocument(uri);
-      await vscode.window.showTextDocument(doc, { preview: true, preserveFocus: true });
+      if (oldContent !== null && oldContent !== newContent) {
+        // Show diff: write old content to a temp file, then open vscode.diff
+        const tmpDir = path.join(os.tmpdir(), 'vscode-acp-diffs');
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpDir));
+        const oldUri = vscode.Uri.file(
+          path.join(tmpDir, path.basename(params.path))
+        );
+        await vscode.workspace.fs.writeFile(oldUri, Buffer.from(oldContent, 'utf-8'));
+
+        await vscode.commands.executeCommand(
+          'vscode.diff',
+          oldUri,
+          uri,
+          `${path.basename(params.path)} (before → after)`
+        );
+      } else if (oldContent === null) {
+        // New file: open in editor
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc, { preview: true, preserveFocus: true });
+      }
+      // If oldContent === newContent, no change — do nothing
 
       return {};
     } catch (e) {

--- a/src/handlers/FileSystemHandler.ts
+++ b/src/handlers/FileSystemHandler.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
-import * as os from 'os';
 import { log, logError } from '../utils/Logger';
 
 import type {
@@ -58,48 +56,20 @@ export class FileSystemHandler {
 
   /**
    * Write a text file. Creates parent directories if needed.
-   * Shows a diff view for existing files so the user can review changes.
+   * Opens the file in the editor so the user can see changes.
    */
   async writeTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
     log(`writeTextFile: ${params.path}`);
 
     try {
       const uri = vscode.Uri.file(params.path);
-      const newContent = params.content;
-      const encoded = Buffer.from(newContent, 'utf-8');
-
-      // Read old content (if file exists) before overwriting
-      let oldContent: string | null = null;
-      try {
-        const oldRaw = await vscode.workspace.fs.readFile(uri);
-        oldContent = Buffer.from(oldRaw).toString('utf-8');
-      } catch {
-        // File doesn't exist yet — no diff needed
-      }
+      const encoded = Buffer.from(params.content, 'utf-8');
 
       await vscode.workspace.fs.writeFile(uri, encoded);
 
-      if (oldContent !== null && oldContent !== newContent) {
-        // Show diff: write old content to a temp file, then open vscode.diff
-        const tmpDir = path.join(os.tmpdir(), 'vscode-acp-diffs');
-        await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpDir));
-        const oldUri = vscode.Uri.file(
-          path.join(tmpDir, path.basename(params.path))
-        );
-        await vscode.workspace.fs.writeFile(oldUri, Buffer.from(oldContent, 'utf-8'));
-
-        await vscode.commands.executeCommand(
-          'vscode.diff',
-          oldUri,
-          uri,
-          `${path.basename(params.path)} (before → after)`
-        );
-      } else if (oldContent === null) {
-        // New file: open in editor
-        const doc = await vscode.workspace.openTextDocument(uri);
-        await vscode.window.showTextDocument(doc, { preview: true, preserveFocus: true });
-      }
-      // If oldContent === newContent, no change — do nothing
+      // Open the file in the editor so the user sees the change
+      const doc = await vscode.workspace.openTextDocument(uri);
+      await vscode.window.showTextDocument(doc, { preview: true, preserveFocus: true });
 
       return {};
     } catch (e) {


### PR DESCRIPTION
## Summary

Adds [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) as a pre-configured ACP agent and improves file-edit visibility for agents that edit files through their own tools.

Reasonix is a DeepSeek-native coding agent. It exposes `reasonix acp` over stdio NDJSON JSON-RPC, matching the same direct-binary integration pattern as Kiro CLI and Hermes Agent.

- `command = "reasonix"`
- `args = ["acp"]`

## Why

Reasonix users currently have to configure the agent manually in `settings.json`. A pre-configured entry makes it discoverable and reduces setup friction.

While testing Reasonix through ACP, I also found that some agents write files directly through their own tooling instead of calling the client's `writeTextFile` method. The client therefore needs to follow ACP `tool_call` / `tool_call_update` notifications to show the user which files are being edited and to open a final diff.

## Changes

- Add `Reasonix` to `acp.agents` defaults in `package.json`
- Add Reasonix to the pre-configured agents table in `README.md`
- Add a `CHANGELOG.md` entry under Unreleased
- Add `DiffPreviewHandler` for edit-kind tool calls
- Fix diff preview handling to read ACP notifications from `params.update`
- Track `toolCallId` state across incremental `tool_call_update` payloads
- Extract edited file paths from `locations`, diff content, raw tool input, and title fallback
- Highlight active edit locations while an edit tool is running, then open a before/after diff on completion

## Validation

- Verified locally that `reasonix acp` spawns successfully via vscode-acp
- Verified ACP traffic contains `tool_call` / `tool_call_update` notifications from Reasonix
- Verified chat, filesystem reads, permission prompts, and tool-call streaming locally
- Ran `npm run compile-tests -- --pretty false`
- Ran `npm run lint`
- Ran `npm run compile`

## Compatibility

- Existing agent entries are unchanged.
- Reasonix requires `reasonix` to be on PATH (`brew install reasonix` or install from [GitHub Releases](https://github.com/esengine/DeepSeek-Reasonix/releases)).
- Diff/follow-along behavior is best-effort and only activates when an agent emits edit-kind tool calls or file path metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
