### PR TITLE
fix: ignore Enter keydown during IME composition for CJK input

### DIFF
--- a/src/ui/ChatWebviewProvider.ts
+++ b/src/ui/ChatWebviewProvider.ts
@@ -1390,7 +1390,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           selectSlashCommand(slashFilteredCommands[slashPopupSelectedIdx]);
           return;
         }
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
           e.preventDefault();
           selectSlashCommand(slashFilteredCommands[slashPopupSelectedIdx]);
           return;
@@ -1402,7 +1402,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         }
       }
 
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
         e.preventDefault();
         if (isProcessing) {
           handleCancel();


### PR DESCRIPTION
This pull request makes a small but important improvement to the chat input handling in `ChatWebviewProvider.ts`. It ensures that the Enter key only triggers actions when the user is not in the middle of composing text (such as when using an IME for non-Latin characters), preventing accidental submissions.

- User input handling:
  * Updated Enter key event checks to include a condition for `!e.isComposing`, so actions are not triggered while the user is composing text with an IME. (`src/ui/ChatWebviewProvider.ts`) [[1]](diffhunk://#diff-0cbe574413ba7aeadb73640e0bee7ffad9915868ec84ea78e9ae33135a0cc490L1393-R1393) [[2]](diffhunk://#diff-0cbe574413ba7aeadb73640e0bee7ffad9915868ec84ea78e9ae33135a0cc490L1405-R1405)