### PR TITLE
fix: respect ACP message boundaries in chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "marked": "^15.0.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
@@ -23,6 +24,7 @@
         "@vscode/test-electron": "^2.4.1",
         "@vscode/vsce": "^3.7.1",
         "eslint": "^9.0.0",
+        "jsdom": "^24.1.3",
         "ts-loader": "^9.5.0",
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.0.0",
@@ -40,6 +42,20 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@azu/format-text": {
@@ -259,6 +275,121 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -1138,6 +1269,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.28.0.tgz",
+      "integrity": "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1173,6 +1350,13 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1218,7 +1402,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2048,7 +2231,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2095,7 +2277,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2403,7 +2584,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2999,6 +3179,41 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3029,6 +3244,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3424,7 +3646,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4299,6 +4520,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4669,6 +4903,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4844,6 +5085,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -5751,6 +6033,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -6264,6 +6553,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -6311,6 +6613,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6499,6 +6808,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6570,6 +6886,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -6644,6 +6967,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/schema-utils": {
@@ -7190,6 +7526,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -7510,7 +7853,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7539,6 +7881,45 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7579,8 +7960,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7650,7 +8030,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7698,9 +8077,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7785,6 +8164,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7841,6 +8231,19 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -7855,13 +8258,22 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/webpack": {
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7911,7 +8323,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -8007,6 +8418,20 @@
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -8153,6 +8578,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -8167,6 +8614,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xml2js": {
@@ -8192,6 +8649,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -409,6 +409,7 @@
     "marked": "^15.0.0"
   },
   "devDependencies": {
+    "@types/jsdom": "^28.0.3",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
@@ -418,6 +419,7 @@
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^3.7.1",
     "eslint": "^9.0.0",
+    "jsdom": "^24.1.3",
     "ts-loader": "^9.5.0",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",

--- a/src/test/ChatWebviewProvider.test.ts
+++ b/src/test/ChatWebviewProvider.test.ts
@@ -1,0 +1,174 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { JSDOM } from 'jsdom';
+
+import { SessionUpdateHandler } from '../handlers/SessionUpdateHandler';
+import { ChatWebviewProvider } from '../ui/ChatWebviewProvider';
+
+interface WebviewHarness {
+	dom: JSDOM;
+	postedMessages: any[];
+	dispose: () => void;
+}
+
+function createWebviewHarness(): WebviewHarness {
+	const updateHandler = new SessionUpdateHandler();
+	const provider = new ChatWebviewProvider(
+		vscode.Uri.file('/tmp/acp-client-test'),
+		{} as any,
+		updateHandler,
+	);
+	const webview = {
+		cspSource: 'test-source',
+		asWebviewUri: (uri: vscode.Uri) => uri,
+	} as unknown as vscode.Webview;
+	const html = (provider as any).getHtmlContent(webview) as string;
+	const postedMessages: any[] = [];
+	let state: unknown;
+	const dom = new JSDOM(html, {
+		runScripts: 'dangerously',
+		beforeParse(window) {
+			(window as any).acquireVsCodeApi = () => ({
+				postMessage: (message: any) => postedMessages.push(message),
+				getState: () => state,
+				setState: (nextState: unknown) => {
+					state = nextState;
+					return nextState;
+				},
+			});
+		},
+	});
+
+	return {
+		dom,
+		postedMessages,
+		dispose: () => {
+			dom.window.close();
+			provider.dispose();
+		},
+	};
+}
+
+function sendToWebview(dom: JSDOM, data: Record<string, unknown>): void {
+	dom.window.dispatchEvent(new dom.window.MessageEvent('message', { data }));
+}
+
+function sessionUpdate(dom: JSDOM, update: Record<string, unknown>): void {
+	sendToWebview(dom, { type: 'sessionUpdate', update });
+}
+
+function textContents(dom: JSDOM, selector: string): Array<string | null> {
+	return Array.from(dom.window.document.querySelectorAll(selector), (element) => element.textContent);
+}
+
+suite('Chat webview message grouping', () => {
+	test('reconciles a live user message and separates agent message IDs', () => {
+		const harness = createWebviewHarness();
+		try {
+			sendToWebview(harness.dom, {
+				type: 'state',
+				session: { agentName: 'RunWield', cwd: '/tmp/project' },
+			});
+			const input = harness.dom.window.document.getElementById('promptInput') as HTMLTextAreaElement;
+			input.value = 'hi there';
+			input.dispatchEvent(new harness.dom.window.KeyboardEvent('keydown', {
+				key: 'Enter',
+				bubbles: true,
+			}));
+			assert.ok(harness.postedMessages.some((message) => message.type === 'sendPrompt'));
+
+			sendToWebview(harness.dom, { type: 'promptStart' });
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'user_message_chunk',
+				messageId: 'user-1',
+				content: { type: 'text', text: 'hi there' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'tool_call',
+				toolCallId: 'triage-1',
+				title: 'triage_report',
+				status: 'in_progress',
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'agent_message_chunk',
+				messageId: 'status-1',
+				content: { type: 'text', text: 'Routing Intent: INQUIRY' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'tool_call_update',
+				toolCallId: 'triage-1',
+				status: 'completed',
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'agent_message_chunk',
+				messageId: 'agent-change-1',
+				content: { type: 'text', text: 'Active agent: guide' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'agent_message_chunk',
+				messageId: 'guide-reply-1',
+				content: { type: 'text', text: 'Hi! What can I help you with?' },
+			});
+			sendToWebview(harness.dom, { type: 'promptEnd', stopReason: 'end_turn' });
+
+			assert.deepStrictEqual(textContents(harness.dom, '.message.user'), ['hi there']);
+			assert.deepStrictEqual(textContents(harness.dom, '.message.assistant'), [
+				'Routing Intent: INQUIRY',
+				'Active agent: guide',
+				'Hi! What can I help you with?',
+			]);
+		} finally {
+			harness.dispose();
+		}
+	});
+
+	test('keeps replayed user messages and thought segments separate by message ID', () => {
+		const harness = createWebviewHarness();
+		try {
+			sendToWebview(harness.dom, { type: 'loadSessionStart' });
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'user_message_chunk',
+				messageId: 'user-1',
+				content: { type: 'text', text: 'first ' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'user_message_chunk',
+				messageId: 'user-1',
+				content: { type: 'text', text: 'message' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'user_message_chunk',
+				messageId: 'user-2',
+				content: { type: 'text', text: 'second message' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'agent_thought_chunk',
+				messageId: 'thought-1',
+				content: { type: 'text', text: 'first thought' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'agent_message_chunk',
+				messageId: 'answer-1',
+				content: { type: 'text', text: 'interim answer' },
+			});
+			sessionUpdate(harness.dom, {
+				sessionUpdate: 'agent_thought_chunk',
+				messageId: 'thought-2',
+				content: { type: 'text', text: 'second thought' },
+			});
+			sendToWebview(harness.dom, { type: 'loadSessionEnd', ok: true });
+
+			assert.deepStrictEqual(textContents(harness.dom, '.message.user'), [
+				'first message',
+				'second message',
+			]);
+			assert.deepStrictEqual(textContents(harness.dom, '.thought-content'), [
+				'first thought',
+				'second thought',
+			]);
+			assert.deepStrictEqual(textContents(harness.dom, '.message.assistant'), ['interim answer']);
+		} finally {
+			harness.dispose();
+		}
+	});
+});

--- a/src/ui/ChatWebviewProvider.ts
+++ b/src/ui/ChatWebviewProvider.ts
@@ -1236,6 +1236,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     let currentThoughtEl = null;
     let currentThoughtTextEl = null;
     let currentThoughtText = '';
+    let currentThoughtMessageId = null;
     let thoughtStartTime = null;
     let thoughtEndTime = null;
 
@@ -1306,6 +1307,9 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     if (inputArea) inputArea.classList.add('disabled');
     let currentAssistantEl = null;
     let currentAssistantText = '';
+    let currentAssistantMessageId = null;
+    let replayUserMessageId = null;
+    let pendingOptimisticUser = null;
     let currentTurnEl = null;       // .turn container for current response
     let currentToolsListEl = null;  // .turn-tools-list inside current turn
     let currentToolsCountEl = null; // .turn-tools-summary counter
@@ -1416,7 +1420,13 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       const text = promptInput.value.trim();
       if (!text || isProcessing) return;
 
-      addMessage('user', text);
+      const element = addMessage('user', text);
+      pendingOptimisticUser = {
+        historyIndex: chatHistory.length - 1,
+        element,
+        messageId: null,
+        acknowledgedText: '',
+      };
       promptInput.value = '';
       vscode.postMessage({ type: 'sendPrompt', text });
     }
@@ -1475,6 +1485,9 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       saveState();
       currentAssistantEl = null;
       currentAssistantText = '';
+      currentAssistantMessageId = null;
+      replayUserMessageId = null;
+      pendingOptimisticUser = null;
       toolCalls = {};
       currentTurnEl = null;
       currentToolsListEl = null;
@@ -1483,6 +1496,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       currentThoughtEl = null;
       currentThoughtTextEl = null;
       currentThoughtText = '';
+      currentThoughtMessageId = null;
       thoughtStartTime = null;
       thoughtEndTime = null;
       messagesEl.innerHTML = '';
@@ -1496,9 +1510,9 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     }
 
     function handleLoadSessionEnd(ok) {
-      isLoadingSession = false;
       // Commit any trailing assistant turn captured during the replay.
       finalizeCurrentAssistantTurn();
+      isLoadingSession = false;
       if (loadOverlay) loadOverlay.classList.remove('visible');
       if (inputArea) inputArea.classList.remove('disabled');
       // Batch-render markdown for every assistant message captured during
@@ -2129,13 +2143,17 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       }
     }
 
-    /**
-     * Commit the in-progress assistant turn to chatHistory (without firing
-     * the live promptEnd markdown-render request — replay does that
-     * batched at loadSessionEnd). Resets all per-turn DOM/state pointers so
-     * the next turn starts fresh.
-     */
-    function finalizeCurrentAssistantTurn() {
+    function getMessageId(update) {
+      return typeof update.messageId === 'string' && update.messageId.length > 0
+        ? update.messageId
+        : null;
+    }
+
+    function startsNewMessage(currentMessageId, incomingMessageId, hasContent) {
+      return hasContent && incomingMessageId !== null && incomingMessageId !== currentMessageId;
+    }
+
+    function finalizeCurrentThoughtMessage() {
       if (currentThoughtText) {
         finalizeThought();
         const tEnd = thoughtEndTime || Date.now();
@@ -2144,22 +2162,84 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           text: currentThoughtText,
           durationSec: thoughtStartTime ? Math.round((tEnd - thoughtStartTime) / 1000) : 0,
         });
+        saveState();
+        if (currentThoughtEl && currentThoughtEl.open) {
+          currentThoughtEl.open = false;
+        }
       }
+      currentThoughtEl = null;
+      currentThoughtTextEl = null;
+      currentThoughtText = '';
+      currentThoughtMessageId = null;
+      thoughtStartTime = null;
+      thoughtEndTime = null;
+    }
+
+    function finalizeCurrentAssistantMessage() {
       if (currentAssistantText) {
+        const historyIndex = chatHistory.length;
         chatHistory.push({ kind: 'message', role: 'assistant', text: currentAssistantText });
         saveState();
+        if (!isLoadingSession && currentAssistantEl) {
+          vscode.postMessage({
+            type: 'renderMarkdown',
+            items: [{ index: historyIndex, text: currentAssistantText }]
+          });
+        }
       }
       currentAssistantEl = null;
       currentAssistantText = '';
+      currentAssistantMessageId = null;
+    }
+
+    function finalizeUnidentifiedStreamingMessages() {
+      if (currentThoughtText && currentThoughtMessageId === null) {
+        finalizeCurrentThoughtMessage();
+      }
+      if (currentAssistantText && currentAssistantMessageId === null) {
+        finalizeCurrentAssistantMessage();
+      }
+    }
+
+    function reconcilePendingUserChunk(update, text) {
+      if (!pendingOptimisticUser) return false;
+      const messageId = getMessageId(update);
+      if (
+        pendingOptimisticUser.messageId !== null &&
+        messageId !== null &&
+        pendingOptimisticUser.messageId !== messageId
+      ) {
+        pendingOptimisticUser = null;
+        return false;
+      }
+
+      if (messageId !== null) pendingOptimisticUser.messageId = messageId;
+      pendingOptimisticUser.acknowledgedText += text;
+      const historyItem = chatHistory[pendingOptimisticUser.historyIndex];
+      if (!historyItem || historyItem.kind !== 'message' || historyItem.role !== 'user') {
+        pendingOptimisticUser = null;
+        return false;
+      }
+
+      historyItem.text = pendingOptimisticUser.acknowledgedText;
+      if (pendingOptimisticUser.element) {
+        pendingOptimisticUser.element.textContent = pendingOptimisticUser.acknowledgedText;
+      }
+      saveState();
+      return true;
+    }
+
+    /**
+     * Commit the in-progress messages and reset the containing turn. Replay
+     * markdown rendering remains batched until loadSessionEnd.
+     */
+    function finalizeCurrentAssistantTurn() {
+      finalizeCurrentThoughtMessage();
+      finalizeCurrentAssistantMessage();
       currentTurnEl = null;
       currentToolsListEl = null;
       currentToolsCountEl = null;
       currentToolCount = 0;
-      currentThoughtEl = null;
-      currentThoughtTextEl = null;
-      currentThoughtText = '';
-      thoughtStartTime = null;
-      thoughtEndTime = null;
     }
 
     function addThoughtDOM(text, durationSec) {
@@ -2240,6 +2320,8 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           setProcessing(true);
           currentAssistantEl = null;
           currentAssistantText = '';
+          currentAssistantMessageId = null;
+          replayUserMessageId = null;
           currentTurnEl = null;
           currentToolsListEl = null;
           currentToolsCountEl = null;
@@ -2247,35 +2329,17 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           currentThoughtEl = null;
           currentThoughtTextEl = null;
           currentThoughtText = '';
+          currentThoughtMessageId = null;
           thoughtStartTime = null;
           thoughtEndTime = null;
           break;
 
         case 'promptEnd':
-          // Finalize thought block if present
-          if (currentThoughtText) {
-            finalizeThought();
-            const tEnd = thoughtEndTime || Date.now();
-            chatHistory.push({
-              kind: 'thought',
-              text: currentThoughtText,
-              durationSec: thoughtStartTime ? Math.round((tEnd - thoughtStartTime) / 1000) : 0,
-            });
-          }
-          if (currentAssistantText) {
-            chatHistory.push({ kind: 'message', role: 'assistant', text: currentAssistantText });
-            saveState();
-            // Request markdown rendering from extension host
-            if (currentAssistantEl) {
-              vscode.postMessage({
-                type: 'renderMarkdown',
-                items: [{ index: chatHistory.length - 1, text: currentAssistantText }]
-              });
-            }
-          }
+          finalizeCurrentThoughtMessage();
+          finalizeCurrentAssistantMessage();
           setProcessing(false);
-          currentAssistantEl = null;
-          currentAssistantText = '';
+          pendingOptimisticUser = null;
+          replayUserMessageId = null;
           // Auto-collapse tool calls in completed turns
           if (currentToolsListEl && currentToolCount > 3) {
             currentToolsListEl.classList.add('collapsed');
@@ -2291,6 +2355,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           currentThoughtEl = null;
           currentThoughtTextEl = null;
           currentThoughtText = '';
+          currentThoughtMessageId = null;
           thoughtStartTime = null;
           thoughtEndTime = null;
           break;
@@ -2301,6 +2366,9 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           saveState();
           currentAssistantEl = null;
           currentAssistantText = '';
+          currentAssistantMessageId = null;
+          replayUserMessageId = null;
+          pendingOptimisticUser = null;
           toolCalls = {};
           currentTurnEl = null;
           currentToolsListEl = null;
@@ -2309,6 +2377,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           currentThoughtEl = null;
           currentThoughtTextEl = null;
           currentThoughtText = '';
+          currentThoughtMessageId = null;
           thoughtStartTime = null;
           thoughtEndTime = null;
           availableCommands = [];
@@ -2388,20 +2457,24 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     function handleUpdate(update) {
       if (!update) return;
       const type = update.sessionUpdate;
+      if (type !== 'user_message_chunk') replayUserMessageId = null;
 
       switch (type) {
         case 'agent_message_chunk': {
           const content = update.content;
           if (content && content.type === 'text' && content.text) {
+            const messageId = getMessageId(update);
+            if (startsNewMessage(currentAssistantMessageId, messageId, !!currentAssistantText)) {
+              finalizeCurrentAssistantMessage();
+            }
+            if (currentThoughtText) {
+              finalizeCurrentThoughtMessage();
+            }
+            if (!currentAssistantText) currentAssistantMessageId = messageId;
             currentAssistantText += content.text;
             // Don't create visible element until there's non-whitespace content
             if (!currentAssistantEl && !currentAssistantText.trim()) {
               break;
-            }
-            // Auto-collapse thought when assistant text starts
-            if (currentThoughtEl && currentThoughtEl.open) {
-              finalizeThought();
-              currentThoughtEl.open = false;
             }
             if (!currentAssistantEl) {
               // Create a turn container, assistant text goes inside it
@@ -2422,23 +2495,30 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         }
 
         case 'user_message_chunk': {
-          // Only the session/load replay path emits this; live prompts
-          // never echo the user's message. Use it to break apart historical
-          // turns: finalize any pending assistant turn first, then append
-          // the historical user message.
           const content = update.content;
           if (content && content.type === 'text' && typeof content.text === 'string') {
+            if (!isLoadingSession && reconcilePendingUserChunk(update, content.text)) {
+              break;
+            }
+
             finalizeCurrentAssistantTurn();
-            // Coalesce consecutive user chunks into one message.
+            const messageId = getMessageId(update);
             const last = chatHistory[chatHistory.length - 1];
-            if (last && last.kind === 'message' && last.role === 'user') {
+            const sameUserMessage = last && last.kind === 'message' && last.role === 'user' && (
+              messageId !== null
+                ? replayUserMessageId === messageId
+                : replayUserMessageId === null
+            );
+            if (sameUserMessage) {
               last.text += content.text;
               const allUser = messagesEl.querySelectorAll('.message.user');
               const el = allUser[allUser.length - 1];
               if (el) el.textContent = last.text;
+              saveState();
             } else {
               addMessage('user', content.text);
             }
+            replayUserMessageId = messageId;
           }
           break;
         }
@@ -2446,6 +2526,13 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         case 'agent_thought_chunk': {
           const content = update.content;
           if (content && content.type === 'text') {
+            const messageId = getMessageId(update);
+            if (startsNewMessage(currentThoughtMessageId, messageId, !!currentThoughtText)) {
+              finalizeCurrentThoughtMessage();
+            }
+            if (currentAssistantText) {
+              finalizeCurrentAssistantMessage();
+            }
             if (!currentThoughtEl) {
               // Create thought block inside turn
               if (!currentTurnEl) {
@@ -2461,9 +2548,10 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
                 '<summary><span class="thought-indicator"></span> Thinking\u2026</summary>' +
                 '<div class="thought-content"></div>';
               currentThoughtTextEl = currentThoughtEl.querySelector('.thought-content');
-              currentTurnEl.insertBefore(currentThoughtEl, currentTurnEl.firstChild);
+              currentTurnEl.insertBefore(currentThoughtEl, currentTurnEl.querySelector('.turn-tools'));
               thoughtStartTime = Date.now();
               currentThoughtText = '';
+              currentThoughtMessageId = messageId;
             }
             currentThoughtText += content.text;
             currentThoughtTextEl.textContent = currentThoughtText;
@@ -2473,6 +2561,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         }
 
         case 'tool_call': {
+          finalizeUnidentifiedStreamingMessages();
           const tc = update;
           addToolCall(
             tc.toolCallId || 'unknown',
@@ -2483,6 +2572,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         }
 
         case 'tool_call_update': {
+          finalizeUnidentifiedStreamingMessages();
           updateToolCall(
             update.toolCallId || 'unknown',
             update.status || 'completed',
@@ -2492,6 +2582,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         }
 
         case 'plan': {
+          finalizeUnidentifiedStreamingMessages();
           addPlan(update);
           break;
         }


### PR DESCRIPTION
## Summary

- reconcile live user_message_chunk acknowledgments with the optimistic prompt instead of appending duplicate text
- split agent, thought, and replayed user messages when their ACP messageId changes
- retain legacy boundaries around tool and plan updates when an agent omits messageId
- add JSDOM regressions for live RunWield-style routing updates, replayed user messages, and multiple thought segments

## Context

ACP v1 now defines messageId as the boundary for streamed user, agent, and thought messages. The chat renderer previously accumulated every agent chunk into one buffer and assumed user_message_chunk only appeared during session replay. Agents that acknowledge a live prompt therefore duplicated the user text, while multiple agent messages in one turn were concatenated.

Fixes #12

## Validation

- npm test — 5 passing
- npm run package — production webpack build passes