### PR TITLE
feat(chat): allow typing and sending while a turn is running

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,7 +370,20 @@
             }
           }
         },
-        "acp.autoApprovePermissions": {
+        "acp.chat.midRunPrompt": {
+      "type": "string",
+      "enum": [
+        "queue",
+        "send"
+      ],
+      "enumDescriptions": [
+        "Hold the prompt until the running turn finishes, then send it.",
+        "Send the prompt right away and let the agent decide what to do with it. Agents that can steer a running turn apply it immediately; agents that do not accept a prompt mid-turn answer with an error."
+      ],
+      "default": "queue",
+      "description": "What happens to a prompt you send while the agent is still working on the previous one."
+    },
+    "acp.autoApprovePermissions": {
           "type": "string",
           "enum": [
             "ask",

--- a/src/ui/ChatWebviewProvider.ts
+++ b/src/ui/ChatWebviewProvider.ts
@@ -16,6 +16,10 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
   private view?: vscode.WebviewView;
   private updateListener: SessionUpdateListener;
   private _hasChatContent = false;
+  /** Prompts sent to the agent that have not returned yet. */
+  private inFlightPrompts = 0;
+  /** Prompts typed during a turn that wait for that turn to finish. */
+  private pendingPrompts: string[] = [];
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -169,6 +173,20 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    // A prompt typed while the agent is still working either waits for the
+    // running turn or goes straight to the agent. Agents differ in what they
+    // do with a prompt that arrives mid-turn: some steer the running turn
+    // with it, others reject it, so waiting is the default.
+    if (this.inFlightPrompts > 0) {
+      const midRunPrompt = vscode.workspace
+        .getConfiguration('acp')
+        .get<string>('chat.midRunPrompt', 'queue');
+      if (midRunPrompt !== 'send') {
+        this.pendingPrompts.push(text);
+        return;
+      }
+    }
+
     sendEvent('chat/messageSent', {
       agentName: this.sessionManager.getActiveAgentName() ?? '',
     }, {
@@ -180,25 +198,44 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     this.sessionManager.recordFirstPrompt(activeId, text);
 
     // Tell webview we're processing
-    this.postMessage({ type: 'promptStart' });
+    if (this.inFlightPrompts++ === 0) {
+      this.postMessage({ type: 'promptStart' });
+    }
 
     try {
       const response = await this.sessionManager.sendPrompt(activeId, text);
+      this.sessionManager.touchHistory(activeId);
       // Render the accumulated assistant text as markdown
       // The webview will have sent us the raw text via promptEnd handling
-      this.postMessage({
+      this.finishPrompt({
         type: 'promptEnd',
         stopReason: response.stopReason,
         usage: (response as any).usage,
       });
-      this.sessionManager.touchHistory(activeId);
     } catch (e: any) {
       logError('Prompt failed', e);
       this.postMessage({
         type: 'error',
         message: e.message || 'Prompt failed',
       });
-      this.postMessage({ type: 'promptEnd', stopReason: 'error' });
+      this.finishPrompt({ type: 'promptEnd', stopReason: 'error' });
+    }
+  }
+
+  /**
+   * End one prompt request. The webview leaves its processing state only once
+   * every in-flight prompt has returned, so the quick reply to a prompt sent
+   * mid-turn does not clear the spinner of the turn that is still running.
+   */
+  private finishPrompt(endMessage: Record<string, unknown>): void {
+    this.inFlightPrompts = Math.max(0, this.inFlightPrompts - 1);
+    if (this.inFlightPrompts > 0) {
+      return;
+    }
+    this.postMessage(endMessage);
+    const next = this.pendingPrompts.shift();
+    if (next !== undefined) {
+      void this.handleSendPrompt(next);
     }
   }
 
@@ -349,6 +386,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
    * Called when starting a new conversation.
    */
   clearChat(): void {
+    this.pendingPrompts = [];
     this._hasChatContent = false;
     this.postMessage({ type: 'clearChat' });
   }
@@ -1404,17 +1442,13 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        if (isProcessing) {
-          handleCancel();
-        } else {
-          handleSend();
-        }
+        handleSend();
       }
     });
 
     function handleSend() {
       const text = promptInput.value.trim();
-      if (!text || isProcessing) return;
+      if (!text) return;
 
       addMessage('user', text);
       promptInput.value = '';
@@ -1450,7 +1484,6 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         sendStopBtn.className = 'send-stop-btn stop';
         sendStopBtn.textContent = '■ Stop';
         sendStopBtn.disabled = false;
-        promptInput.disabled = true;
         statusEl.innerHTML = '<span class="spinner"></span>';
       } else {
         sendStopBtn.className = 'send-stop-btn send';


### PR DESCRIPTION
Refs #31

## Problem

While a turn is running the chat composer is disabled and Enter is bound to cancel, so a correction or the next task has to be written somewhere else and pasted back once the agent is done.

## Change

The composer stays enabled for the whole turn and Enter always sends.

A prompt sent while the agent is still working waits for the running turn and is sent as soon as that turn ends. The new setting `acp.chat.midRunPrompt` switches this to `send`, which forwards the prompt to the agent immediately.

Waiting is the default because agents disagree about what a prompt arriving mid-turn means. Hermes Agent, for example, redirects the running turn with it or queues it itself and answers right away, while other agents may reject it. The ACP prompt turn docs do not specify the case, so the safe behavior is the default and the immediate one is opt-in.

`ChatWebviewProvider` now counts in-flight prompts. `promptStart` goes to the webview when the first prompt starts and `promptEnd` only after the last one returns, so the fast reply to a mid-turn prompt does not clear the spinner of the turn that is still running. Queued prompts are dropped when the chat is cleared.

Cancel is unchanged and stays on the Stop button.

## Testing

`npm run lint`, `npm run compile-tests`, `npm run package` and `npm test` pass locally on Linux.
