### PR TITLE
feat: answer agent elicitations in the chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "marked": "^15.0.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^30.0.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
@@ -23,6 +24,7 @@
         "@vscode/test-electron": "^2.4.1",
         "@vscode/vsce": "^3.7.1",
         "eslint": "^9.0.0",
+        "jsdom": "^30.0.1",
         "ts-loader": "^9.5.0",
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.0.0",
@@ -40,6 +42,59 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@azu/format-text": {
@@ -259,6 +314,159 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -481,6 +689,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1138,6 +1364,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^8.9.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.1.tgz",
+      "integrity": "sha512-ZpkgovMu+ALwfuo6Bgys8H82gHJ25d4ARMB51FD2BeLnUCDRgY6N3caWk3N6CtKR77gHmRKYHnLF723owNYPNA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1173,6 +1445,13 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1218,7 +1497,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2048,7 +2326,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2095,7 +2372,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2281,6 +2557,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2403,7 +2689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2986,6 +3271,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -2997,6 +3296,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -3029,6 +3367,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3424,7 +3769,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4299,6 +4643,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4669,6 +5026,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4844,6 +5208,103 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/json-buffer": {
@@ -5219,6 +5680,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -6646,6 +7114,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -6933,6 +7414,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -7189,6 +7680,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/table": {
       "version": "6.9.0",
@@ -7510,13 +8008,32 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -7539,6 +8056,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7579,8 +8122,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7650,7 +8192,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7841,6 +8382,19 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -7855,13 +8409,22 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack": {
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7911,7 +8474,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -8009,6 +8571,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8169,6 +8746,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -8192,6 +8779,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -409,6 +409,7 @@
     "marked": "^15.0.0"
   },
   "devDependencies": {
+    "@types/jsdom": "^30.0.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
@@ -418,6 +419,7 @@
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^3.7.1",
     "eslint": "^9.0.0",
+    "jsdom": "^30.0.1",
     "ts-loader": "^9.5.0",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",

--- a/src/core/AcpClientImpl.ts
+++ b/src/core/AcpClientImpl.ts
@@ -18,11 +18,14 @@ import type {
   KillTerminalResponse,
   ReleaseTerminalRequest,
   ReleaseTerminalResponse,
+  CreateElicitationRequest,
+  CreateElicitationResponse,
 } from '@agentclientprotocol/sdk';
 
 import { FileSystemHandler } from '../handlers/FileSystemHandler';
 import { TerminalHandler } from '../handlers/TerminalHandler';
 import { PermissionHandler } from '../handlers/PermissionHandler';
+import { ElicitationHandler } from '../handlers/ElicitationHandler';
 import { SessionUpdateHandler } from '../handlers/SessionUpdateHandler';
 import { log } from '../utils/Logger';
 
@@ -41,6 +44,7 @@ export class AcpClientImpl implements Client {
     private readonly terminalHandler: TerminalHandler,
     private readonly permissionHandler: PermissionHandler,
     private readonly sessionUpdateHandler: SessionUpdateHandler,
+    private readonly elicitationHandler: ElicitationHandler,
   ) {}
 
   setAgent(agent: Agent): void {
@@ -61,6 +65,12 @@ export class AcpClientImpl implements Client {
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
     this.sessionUpdateHandler.handleUpdate(params);
+  }
+
+  async unstable_createElicitation(
+    params: CreateElicitationRequest,
+  ): Promise<CreateElicitationResponse> {
+    return this.elicitationHandler.createElicitation(params);
   }
 
   // --- File system methods ---

--- a/src/core/ConnectionManager.ts
+++ b/src/core/ConnectionManager.ts
@@ -9,6 +9,7 @@ import { FileSystemHandler } from '../handlers/FileSystemHandler';
 import { TerminalHandler } from '../handlers/TerminalHandler';
 import { PermissionHandler } from '../handlers/PermissionHandler';
 import { SessionUpdateHandler } from '../handlers/SessionUpdateHandler';
+import { ElicitationHandler } from '../handlers/ElicitationHandler';
 import { log, logError, logTraffic } from '../utils/Logger';
 import { version as extensionVersion } from '../../package.json';
 
@@ -27,6 +28,7 @@ export class ConnectionManager {
 
   constructor(
     private readonly sessionUpdateHandler: SessionUpdateHandler,
+    private readonly elicitationHandler: ElicitationHandler,
   ) {}
 
   /**
@@ -60,6 +62,7 @@ export class ConnectionManager {
       terminalHandler,
       permissionHandler,
       this.sessionUpdateHandler,
+      this.elicitationHandler,
     );
 
     // Create connection — toClient factory receives the Agent proxy
@@ -85,6 +88,9 @@ export class ConnectionManager {
           writeTextFile: true,
         },
         terminal: true,
+        elicitation: {
+          form: {},
+        },
       },
     });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { ConnectionManager } from './core/ConnectionManager';
 import { SessionManager } from './core/SessionManager';
 import { SessionHistoryStore } from './core/SessionHistoryStore';
 import { SessionUpdateHandler } from './handlers/SessionUpdateHandler';
+import { ElicitationHandler } from './handlers/ElicitationHandler';
 import { SessionTreeProvider } from './ui/SessionTreeProvider';
 import { StatusBarManager } from './ui/StatusBarManager';
 import { ChatWebviewProvider } from './ui/ChatWebviewProvider';
@@ -22,8 +23,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // --- Core services ---
   const sessionUpdateHandler = new SessionUpdateHandler();
+  const elicitationHandler = new ElicitationHandler();
   const agentManager = new AgentManager();
-  const connectionManager = new ConnectionManager(sessionUpdateHandler);
+  const connectionManager = new ConnectionManager(sessionUpdateHandler, elicitationHandler);
   const sessionManager = new SessionManager(
     agentManager,
     connectionManager,
@@ -49,6 +51,9 @@ export function activate(context: vscode.ExtensionContext): void {
     sessionManager,
     sessionUpdateHandler,
   );
+  elicitationHandler.setPresenter((params) => chatWebviewProvider.presentElicitation(params));
+  context.subscriptions.push({ dispose: () => elicitationHandler.setPresenter(undefined) });
+
   const chatViewRegistration = vscode.window.registerWebviewViewProvider(
     ChatWebviewProvider.viewType,
     chatWebviewProvider,

--- a/src/handlers/ElicitationHandler.ts
+++ b/src/handlers/ElicitationHandler.ts
@@ -1,0 +1,38 @@
+import type {
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+} from '@agentclientprotocol/sdk';
+
+import { log } from '../utils/Logger';
+
+/** Presents an elicitation to the user and resolves with their answer. */
+export type ElicitationPresenter = (
+  params: CreateElicitationRequest,
+) => Promise<CreateElicitationResponse>;
+
+/**
+ * Handles elicitation requests: an agent asking the user for structured input
+ * instead of guessing. Only the form mode is supported, matching the client
+ * capability sent during initialize.
+ */
+export class ElicitationHandler {
+  private presenter: ElicitationPresenter | undefined;
+
+  setPresenter(presenter: ElicitationPresenter | undefined): void {
+    this.presenter = presenter;
+  }
+
+  async createElicitation(
+    params: CreateElicitationRequest,
+  ): Promise<CreateElicitationResponse> {
+    if (params.mode !== 'form') {
+      log(`createElicitation: declining unsupported mode ${params.mode}`);
+      return { action: 'decline' };
+    }
+    if (!this.presenter) {
+      log('createElicitation: declining, no presenter registered');
+      return { action: 'decline' };
+    }
+    return this.presenter(params);
+  }
+}

--- a/src/test/Elicitation.test.ts
+++ b/src/test/Elicitation.test.ts
@@ -1,0 +1,190 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { JSDOM } from 'jsdom';
+
+import { SessionUpdateHandler } from '../handlers/SessionUpdateHandler';
+import { ChatWebviewProvider } from '../ui/ChatWebviewProvider';
+
+interface WebviewHarness {
+	dom: JSDOM;
+	postedMessages: any[];
+	dispose: () => void;
+}
+
+function createWebviewHarness(): WebviewHarness {
+	const updateHandler = new SessionUpdateHandler();
+	const provider = new ChatWebviewProvider(
+		vscode.Uri.file('/tmp/acp-client-test'),
+		{} as any,
+		updateHandler,
+	);
+	const webview = {
+		cspSource: 'test-source',
+		asWebviewUri: (uri: vscode.Uri) => uri,
+	} as unknown as vscode.Webview;
+	const html = (provider as any).getHtmlContent(webview) as string;
+	const postedMessages: any[] = [];
+	let state: unknown;
+	const dom = new JSDOM(html, {
+		runScripts: 'dangerously',
+		beforeParse(window) {
+			(window as any).acquireVsCodeApi = () => ({
+				postMessage: (message: any) => postedMessages.push(message),
+				getState: () => state,
+				setState: (nextState: unknown) => {
+					state = nextState;
+					return nextState;
+				},
+			});
+		},
+	});
+
+	return {
+		dom,
+		postedMessages,
+		dispose: () => {
+			dom.window.close();
+			provider.dispose();
+		},
+	};
+}
+
+function sendToWebview(dom: JSDOM, data: Record<string, unknown>): void {
+	dom.window.dispatchEvent(new dom.window.MessageEvent('message', { data }));
+}
+
+function lastResult(postedMessages: any[]): unknown {
+	return JSON.parse(JSON.stringify(postedMessages[postedMessages.length - 1]));
+}
+
+function buttonLabels(dom: JSDOM): Array<string | null> {
+	return Array.from(dom.window.document.querySelectorAll('.elicitation-actions button')).map(
+		(el) => el.textContent,
+	);
+}
+
+function clickButton(dom: JSDOM, label: string): void {
+	const button = Array.from(
+		dom.window.document.querySelectorAll('.elicitation-actions button'),
+	).find((el) => el.textContent === label);
+	assert.ok(button, `button ${label} exists`);
+	(button as HTMLElement).click();
+}
+
+suite('Elicitation', () => {
+	test('answers a single choice question with one click', () => {
+		const harness = createWebviewHarness();
+		try {
+			sendToWebview(harness.dom, {
+				type: 'elicitation',
+				id: 'elicitation-1',
+				message: 'Which database should I use?',
+				schema: {
+					type: 'object',
+					properties: {
+						database: {
+							type: 'string',
+							oneOf: [
+								{ const: 'postgres', title: 'PostgreSQL' },
+								{ const: 'sqlite', title: 'SQLite' },
+							],
+						},
+					},
+					required: ['database'],
+				},
+			});
+
+			assert.deepStrictEqual(buttonLabels(harness.dom), ['PostgreSQL', 'SQLite', 'Decline']);
+			clickButton(harness.dom, 'SQLite');
+
+			assert.deepStrictEqual(lastResult(harness.postedMessages), {
+				type: 'elicitationResult',
+				id: 'elicitation-1',
+				action: 'accept',
+				content: { database: 'sqlite' },
+			});
+		} finally {
+			harness.dispose();
+		}
+	});
+
+	test('holds the send button until every required field is filled', () => {
+		const harness = createWebviewHarness();
+		try {
+			sendToWebview(harness.dom, {
+				type: 'elicitation',
+				id: 'elicitation-2',
+				message: 'Where should the service run?',
+				schema: {
+					type: 'object',
+					properties: {
+						host: { type: 'string', title: 'Host' },
+						port: { type: 'integer', title: 'Port', default: 8080 },
+						tls: { type: 'boolean', title: 'Enable TLS' },
+					},
+					required: ['host', 'port'],
+				},
+			});
+
+			const document = harness.dom.window.document;
+			const send = Array.from(document.querySelectorAll('.elicitation-actions button')).find(
+				(el) => el.textContent === 'Send',
+			) as HTMLButtonElement;
+			assert.strictEqual(send.disabled, true, 'send starts disabled');
+
+			const host = document.querySelector('input[type="text"]') as HTMLInputElement;
+			host.value = 'db-1';
+			host.dispatchEvent(new harness.dom.window.Event('input'));
+			assert.strictEqual(send.disabled, false, 'send unlocks once host is set');
+
+			(document.querySelector('input[type="checkbox"]') as HTMLInputElement).click();
+			send.click();
+
+			assert.deepStrictEqual(lastResult(harness.postedMessages), {
+				type: 'elicitationResult',
+				id: 'elicitation-2',
+				action: 'accept',
+				content: { host: 'db-1', port: 8080, tls: true },
+			});
+		} finally {
+			harness.dispose();
+		}
+	});
+
+	test('reports a declined question and locks the card', () => {
+		const harness = createWebviewHarness();
+		try {
+			sendToWebview(harness.dom, {
+				type: 'elicitation',
+				id: 'elicitation-3',
+				message: 'Should I delete the branch?',
+				schema: {
+					type: 'object',
+					properties: {
+						answer: { type: 'string', enum: ['yes', 'no'] },
+					},
+				},
+			});
+
+			clickButton(harness.dom, 'Decline');
+
+			assert.deepStrictEqual(lastResult(harness.postedMessages), {
+				type: 'elicitationResult',
+				id: 'elicitation-3',
+				action: 'decline',
+				content: null,
+			});
+			const card = harness.dom.window.document.querySelector('.elicitation');
+			assert.ok(card!.classList.contains('answered'));
+
+			clickButton(harness.dom, 'yes');
+			assert.strictEqual(
+				harness.postedMessages.filter((m) => m.type === 'elicitationResult').length,
+				1,
+				'an answered question ignores further clicks',
+			);
+		} finally {
+			harness.dispose();
+		}
+	});
+});

--- a/src/ui/ChatWebviewProvider.ts
+++ b/src/ui/ChatWebviewProvider.ts
@@ -2,7 +2,12 @@ import * as vscode from 'vscode';
 import { marked } from 'marked';
 import { SessionManager } from '../core/SessionManager';
 import { SessionUpdateHandler, SessionUpdateListener } from '../handlers/SessionUpdateHandler';
-import type { SessionNotification } from '@agentclientprotocol/sdk';
+import type {
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+  ElicitationContentValue,
+  SessionNotification,
+} from '@agentclientprotocol/sdk';
 import { logError } from '../utils/Logger';
 import { sendEvent } from '../utils/TelemetryManager';
 
@@ -16,6 +21,8 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
   private view?: vscode.WebviewView;
   private updateListener: SessionUpdateListener;
   private _hasChatContent = false;
+  private elicitationSeq = 0;
+  private pendingElicitations = new Map<string, (response: CreateElicitationResponse) => void>();
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -78,6 +85,9 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         case 'cancelTurn':
           await this.handleCancelTurn();
           break;
+        case 'elicitationResult':
+          this.resolveElicitation(message.id, message.action, message.content);
+          break;
         case 'setMode':
           await this.handleSetMode(message.modeId);
           break;
@@ -111,6 +121,10 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 
     webviewView.onDidDispose(() => {
       this.view = undefined;
+      for (const resolve of this.pendingElicitations.values()) {
+        resolve({ action: 'cancel' });
+      }
+      this.pendingElicitations.clear();
     });
   }
 
@@ -200,6 +214,43 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       });
       this.postMessage({ type: 'promptEnd', stopReason: 'error' });
     }
+  }
+
+  /**
+   * Show an agent's elicitation in the chat and wait for the user's answer.
+   */
+  async presentElicitation(
+    params: CreateElicitationRequest,
+  ): Promise<CreateElicitationResponse> {
+    if (!this.view || params.mode !== 'form') {
+      return { action: 'decline' };
+    }
+    this._hasChatContent = true;
+    this.view.show?.(true);
+    const id = `elicitation-${++this.elicitationSeq}`;
+    return new Promise<CreateElicitationResponse>((resolve) => {
+      this.pendingElicitations.set(id, resolve);
+      this.postMessage({
+        type: 'elicitation',
+        id,
+        message: params.message,
+        schema: params.requestedSchema,
+      });
+    });
+  }
+
+  private resolveElicitation(id: string, action: string, content: unknown): void {
+    const resolve = this.pendingElicitations.get(id);
+    if (!resolve) { return; }
+    this.pendingElicitations.delete(id);
+    if (action === 'accept') {
+      resolve({
+        action: 'accept',
+        content: content as Record<string, ElicitationContentValue>,
+      });
+      return;
+    }
+    resolve({ action: action === 'cancel' ? 'cancel' : 'decline' });
   }
 
   /**
@@ -648,6 +699,48 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+
+    .elicitation {
+      border: 1px solid var(--vscode-focusBorder);
+      border-radius: var(--message-radius);
+      padding: 8px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      font-size: 0.9em;
+    }
+    .elicitation.answered { opacity: 0.6; border-color: var(--vscode-panel-border); }
+    .elicitation-message { white-space: pre-wrap; }
+    .elicitation-field { display: flex; flex-direction: column; gap: 4px; }
+    .elicitation-field label { color: var(--vscode-descriptionForeground); }
+    .elicitation-field input[type="text"],
+    .elicitation-field input[type="number"],
+    .elicitation-field select {
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border, transparent);
+      border-radius: 3px;
+      padding: 3px 6px;
+      font-family: inherit;
+      font-size: inherit;
+    }
+    .elicitation-check { display: flex; align-items: center; gap: 6px; }
+    .elicitation-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+    .elicitation-actions button {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border: none;
+      border-radius: 3px;
+      padding: 4px 10px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: inherit;
+    }
+    .elicitation-actions button.secondary {
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+    }
+    .elicitation-actions button:disabled { opacity: 0.5; cursor: default; }
 
     /* Legacy standalone tool-call card (for history restore) */
     .tool-call {
@@ -1955,6 +2048,214 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       return el;
     }
 
+    // An agent can ask for structured input instead of guessing. The request
+    // carries a message and a JSON schema; each property becomes one control.
+    // A single choice property is rendered as buttons so one click answers.
+    function enumOptions(prop) {
+      if (Array.isArray(prop.oneOf)) {
+        return prop.oneOf.map((o) => ({ value: o.const, title: o.title || o.const }));
+      }
+      if (Array.isArray(prop.enum)) {
+        return prop.enum.map((v) => ({ value: v, title: v }));
+      }
+      return null;
+    }
+
+    function multiSelectOptions(prop) {
+      const items = prop.items || {};
+      if (Array.isArray(items.anyOf)) {
+        return items.anyOf.map((o) => ({ value: o.const, title: o.title || o.const }));
+      }
+      if (Array.isArray(items.enum)) {
+        return items.enum.map((v) => ({ value: v, title: v }));
+      }
+      return [];
+    }
+
+    function renderElicitation(msg) {
+      hideEmpty();
+      finalizeCurrentAssistantTurn();
+
+      const schema = msg.schema || {};
+      const properties = schema.properties || {};
+      const keys = Object.keys(properties);
+      const required = Array.isArray(schema.required) ? schema.required : [];
+
+      const card = document.createElement('div');
+      card.className = 'elicitation';
+
+      if (schema.title) {
+        const heading = document.createElement('div');
+        heading.className = 'elicitation-message';
+        heading.textContent = schema.title;
+        card.appendChild(heading);
+      }
+      const text = document.createElement('div');
+      text.className = 'elicitation-message';
+      text.textContent = msg.message || 'The agent is asking for input.';
+      card.appendChild(text);
+
+      const values = {};
+      const readers = [];
+      let answered = false;
+
+      function answer(action, content) {
+        if (answered) return;
+        answered = true;
+        card.classList.add('answered');
+        const controls = card.querySelectorAll('input, select, button');
+        for (let i = 0; i < controls.length; i++) controls[i].disabled = true;
+        vscode.postMessage({ type: 'elicitationResult', id: msg.id, action, content });
+      }
+
+      // One choice, no other fields: the options themselves are the answer.
+      const singleChoice = keys.length === 1 ? enumOptions(properties[keys[0]]) : null;
+      if (singleChoice && singleChoice.length) {
+        const row = document.createElement('div');
+        row.className = 'elicitation-actions';
+        for (const option of singleChoice) {
+          const button = document.createElement('button');
+          button.textContent = option.title;
+          button.addEventListener('click', () => {
+            const content = {};
+            content[keys[0]] = option.value;
+            answer('accept', content);
+          });
+          row.appendChild(button);
+        }
+        const decline = document.createElement('button');
+        decline.className = 'secondary';
+        decline.textContent = 'Decline';
+        decline.addEventListener('click', () => answer('decline', null));
+        row.appendChild(decline);
+        card.appendChild(row);
+        messagesEl.appendChild(card);
+        scrollToBottom();
+        return;
+      }
+
+      for (const key of keys) {
+        const prop = properties[key] || {};
+        const field = document.createElement('div');
+        field.className = 'elicitation-field';
+        const labelText = (prop.title || key) + (required.indexOf(key) >= 0 ? ' *' : '');
+        const options = prop.type === 'string' ? enumOptions(prop) : null;
+
+        if (prop.type === 'boolean') {
+          const wrap = document.createElement('label');
+          wrap.className = 'elicitation-check';
+          const box = document.createElement('input');
+          box.type = 'checkbox';
+          box.checked = prop.default === true;
+          box.addEventListener('change', updateSubmit);
+          wrap.appendChild(box);
+          wrap.appendChild(document.createTextNode(labelText));
+          field.appendChild(wrap);
+          readers.push(() => { values[key] = box.checked; return true; });
+        } else if (prop.type === 'array') {
+          const label = document.createElement('label');
+          label.textContent = labelText;
+          field.appendChild(label);
+          const boxes = [];
+          for (const option of multiSelectOptions(prop)) {
+            const wrap = document.createElement('label');
+            wrap.className = 'elicitation-check';
+            const box = document.createElement('input');
+            box.type = 'checkbox';
+            box.value = option.value;
+            box.checked = Array.isArray(prop.default) && prop.default.indexOf(option.value) >= 0;
+            box.addEventListener('change', updateSubmit);
+            boxes.push(box);
+            wrap.appendChild(box);
+            wrap.appendChild(document.createTextNode(option.title));
+            field.appendChild(wrap);
+          }
+          readers.push(() => {
+            const picked = boxes.filter((b) => b.checked).map((b) => b.value);
+            values[key] = picked;
+            const min = typeof prop.minItems === 'number' ? prop.minItems : 0;
+            return picked.length >= min;
+          });
+        } else if (options && options.length) {
+          const label = document.createElement('label');
+          label.textContent = labelText;
+          field.appendChild(label);
+          const select = document.createElement('select');
+          for (const option of options) {
+            const item = document.createElement('option');
+            item.value = option.value;
+            item.textContent = option.title;
+            select.appendChild(item);
+          }
+          if (prop.default) select.value = prop.default;
+          select.addEventListener('change', updateSubmit);
+          field.appendChild(select);
+          readers.push(() => { values[key] = select.value; return !!select.value; });
+        } else {
+          const label = document.createElement('label');
+          label.textContent = labelText;
+          field.appendChild(label);
+          const input = document.createElement('input');
+          const numeric = prop.type === 'number' || prop.type === 'integer';
+          input.type = numeric ? 'number' : 'text';
+          if (prop.default !== undefined && prop.default !== null) input.value = prop.default;
+          if (prop.description) input.placeholder = prop.description;
+          input.addEventListener('input', updateSubmit);
+          field.appendChild(input);
+          readers.push(() => {
+            const raw = input.value.trim();
+            if (numeric) {
+              values[key] = raw === '' ? null : Number(raw);
+              return raw !== '' && !isNaN(values[key]);
+            }
+            values[key] = raw;
+            return raw !== '';
+          });
+        }
+
+        if (prop.description && prop.type !== 'string') {
+          const hint = document.createElement('label');
+          hint.textContent = prop.description;
+          field.appendChild(hint);
+        }
+        card.appendChild(field);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'elicitation-actions';
+      const submit = document.createElement('button');
+      submit.textContent = 'Send';
+      const decline = document.createElement('button');
+      decline.className = 'secondary';
+      decline.textContent = 'Decline';
+      actions.appendChild(submit);
+      actions.appendChild(decline);
+      card.appendChild(actions);
+
+      function collect() {
+        let complete = true;
+        for (let i = 0; i < readers.length; i++) {
+          const filled = readers[i]();
+          if (!filled && required.indexOf(keys[i]) >= 0) complete = false;
+        }
+        return complete;
+      }
+
+      function updateSubmit() {
+        submit.disabled = !collect();
+      }
+
+      submit.addEventListener('click', () => {
+        if (!collect()) return;
+        answer('accept', values);
+      });
+      decline.addEventListener('click', () => answer('decline', null));
+      updateSubmit();
+
+      messagesEl.appendChild(card);
+      scrollToBottom();
+    }
+
     function hideEmpty() {
       if (emptyState) emptyState.style.display = 'none';
     }
@@ -2234,6 +2535,10 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           } else {
             showNoSession();
           }
+          break;
+
+        case 'elicitation':
+          renderElicitation(msg);
           break;
 
         case 'promptStart':


### PR DESCRIPTION
## Problem

ACP lets an agent ask the user for structured input instead of guessing, through `session/create_elicitation`. The client never advertised the capability and never implemented the method, so a question was refused before it reached anyone. For a user the agent simply proceeds on an assumption.

Related: this is the gap described in [zed-industries/zed#48784](https://github.com/zed-industries/zed/discussions/48784) and [zed-industries/zed#48038](https://github.com/zed-industries/zed/issues/48038), where option payloads arrive but never turn into something clickable.

## Change

`initialize` now advertises `elicitation: { form: {} }`, and `AcpClientImpl.unstable_createElicitation` routes the request into the chat.

A question with a single choice property becomes a row of buttons, so one click answers it. Anything else becomes a small form built from the schema, with text, number, checkbox and multi select controls. Send stays disabled until every property listed in `required` has a value. Declining answers `decline`, and closing the chat view answers `cancel` so the agent is never left waiting on a view that is gone.

URL mode is declined, which is why the capability advertises `form` only.

## Testing

`npm run lint`, `npm test` and `npm run package` pass locally on Linux. Three JSDOM tests cover the one click answer and its payload, a form that unlocks Send once the required field is filled and then reports text, number and boolean together, and a declined question that locks the card against further clicks.

## Note on overlap

The test file brings its own JSDOM harness and adds jsdom to the dev dependencies, as #56 and #64 do. Whichever lands first, I am happy to rebase onto it and drop the duplicate harness.
