### PR TITLE
feat: keep sessions running side by side in tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "marked": "^15.0.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^30.0.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
@@ -23,6 +24,7 @@
         "@vscode/test-electron": "^2.4.1",
         "@vscode/vsce": "^3.7.1",
         "eslint": "^9.0.0",
+        "jsdom": "^30.0.1",
         "ts-loader": "^9.5.0",
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.0.0",
@@ -40,6 +42,59 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@azu/format-text": {
@@ -259,6 +314,159 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -481,6 +689,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1138,6 +1364,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^8.9.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.1.tgz",
+      "integrity": "sha512-ZpkgovMu+ALwfuo6Bgys8H82gHJ25d4ARMB51FD2BeLnUCDRgY6N3caWk3N6CtKR77gHmRKYHnLF723owNYPNA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1173,6 +1445,13 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1218,7 +1497,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2048,7 +2326,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2095,7 +2372,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2281,6 +2557,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2403,7 +2689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2986,6 +3271,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -2997,6 +3296,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -3029,6 +3367,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3424,7 +3769,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4299,6 +4643,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4669,6 +5026,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4844,6 +5208,103 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/json-buffer": {
@@ -5219,6 +5680,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -6646,6 +7114,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -6933,6 +7414,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -7189,6 +7680,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/table": {
       "version": "6.9.0",
@@ -7510,13 +8008,32 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -7539,6 +8056,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7579,8 +8122,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7650,7 +8192,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7841,6 +8382,19 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -7855,13 +8409,22 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack": {
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7911,7 +8474,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -8009,6 +8571,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8169,6 +8746,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -8192,6 +8779,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -409,6 +409,7 @@
     "marked": "^15.0.0"
   },
   "devDependencies": {
+    "@types/jsdom": "^30.0.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
@@ -418,6 +419,7 @@
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^3.7.1",
     "eslint": "^9.0.0",
+    "jsdom": "^30.0.1",
     "ts-loader": "^9.5.0",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -248,9 +248,74 @@ export class SessionManager extends EventEmitter {
     }
 
     const agentName = activeSession.agentName;
-    await this.disconnectAgent(agentName);
-    this.emit('clear-chat');
-    return this.connectToAgent(agentName);
+    const connInfo = this.connectionManager.getConnection(activeSession.agentId);
+    if (!connInfo) {
+      // Connection is gone (agent crashed or was killed): start a fresh one.
+      await this.disconnectAgent(agentName);
+      this.emit('clear-chat');
+      return this.connectToAgent(agentName);
+    }
+
+    // An agent keeps every session of a connection, so opening another one
+    // leaves a session that is still working alone.
+    const sessionInfo = await this.createAcpSession(
+      agentName,
+      activeSession.agentId,
+      connInfo,
+      this.getWorkspaceCwd(),
+    );
+    this.agentSessions.set(agentName, sessionInfo.sessionId);
+    this.activeSessionId = sessionInfo.sessionId;
+    this.emit('active-session-changed', sessionInfo.sessionId);
+    log(`New session ${sessionInfo.sessionId} for agent ${agentName}`);
+    return sessionInfo;
+  }
+
+  /**
+   * Switch to a session that is still live on its agent connection. Unlike
+   * loadSession this needs no replay: the session was never torn down.
+   */
+  activateSession(sessionId: string): SessionInfo | undefined {
+    const session = this.sessions.get(sessionId);
+    if (!session || !this.connectionManager.getConnection(session.agentId)) {
+      return undefined;
+    }
+    if (this.activeSessionId === sessionId) {
+      return session;
+    }
+    this.agentSessions.set(session.agentName, sessionId);
+    this.activeSessionId = sessionId;
+    this.emit('active-session-changed', sessionId);
+    return session;
+  }
+
+  /** Sessions that are still live on a connected agent, oldest first. */
+  listLiveSessions(): SessionInfo[] {
+    return Array.from(this.sessions.values()).filter(
+      (session) => !!this.connectionManager.getConnection(session.agentId),
+    );
+  }
+
+  /**
+   * Move the active pointer away from the previous session before another one
+   * takes over. A session that is still live on its connection is kept so the
+   * user can switch back to it.
+   */
+  private releasePreviousActiveSession(nextSessionId: string): void {
+    const previouslyActive = this.activeSessionId;
+    if (!previouslyActive || previouslyActive === nextSessionId) {
+      return;
+    }
+    const prevSession = this.sessions.get(previouslyActive);
+    if (prevSession) {
+      this.agentSessions.delete(prevSession.agentName);
+      if (!this.connectionManager.getConnection(prevSession.agentId)) {
+        this.sessions.delete(previouslyActive);
+      }
+    } else {
+      this.sessions.delete(previouslyActive);
+    }
+    this.activeSessionId = null;
   }
 
   /**
@@ -268,10 +333,16 @@ export class SessionManager extends EventEmitter {
 
     this.agentManager.killAgent(session.agentId);
     this.connectionManager.removeConnection(session.agentId);
-    this.sessions.delete(sessionId);
+    // One connection can hold several sessions; killing the process ends all.
+    const ownSessionIds = Array.from(this.sessions.values())
+      .filter((candidate) => candidate.agentId === session.agentId)
+      .map((candidate) => candidate.sessionId);
+    for (const ownSessionId of ownSessionIds) {
+      this.sessions.delete(ownSessionId);
+    }
     this.agentSessions.delete(agentName);
 
-    if (this.activeSessionId === sessionId) {
+    if (this.activeSessionId && ownSessionIds.includes(this.activeSessionId)) {
       this.activeSessionId = null;
     }
 
@@ -769,15 +840,7 @@ export class SessionManager extends EventEmitter {
 
     // If the same agent has a different active session, clear it so the
     // load can take over as the new active session.
-    const previouslyActive = this.activeSessionId;
-    if (previouslyActive && previouslyActive !== sessionId) {
-      const prevSession = this.sessions.get(previouslyActive);
-      if (prevSession) {
-        this.agentSessions.delete(prevSession.agentName);
-      }
-      this.sessions.delete(previouslyActive);
-      this.activeSessionId = null;
-    }
+    this.releasePreviousActiveSession(sessionId);
 
     const cwd = this.getWorkspaceCwd();
     const agentId = this.findAgentIdForConnection(conn);
@@ -869,15 +932,7 @@ export class SessionManager extends EventEmitter {
     }
 
     // If the same agent has a different active session, clear it.
-    const previouslyActive = this.activeSessionId;
-    if (previouslyActive && previouslyActive !== sessionId) {
-      const prevSession = this.sessions.get(previouslyActive);
-      if (prevSession) {
-        this.agentSessions.delete(prevSession.agentName);
-      }
-      this.sessions.delete(previouslyActive);
-      this.activeSessionId = null;
-    }
+    this.releasePreviousActiveSession(sessionId);
 
     const cwd = this.getWorkspaceCwd();
     const agentId = this.findAgentIdForConnection(conn);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,16 +168,6 @@ export function activate(context: vscode.ExtensionContext): void {
       return;
     }
 
-    // Confirm if there's existing chat content
-    if (chatWebviewProvider.hasChatContent) {
-      const choice = await vscode.window.showWarningMessage(
-        'Start a new conversation? This will clear the current chat history.',
-        'New Conversation',
-        'Cancel',
-      );
-      if (choice !== 'New Conversation') { return; }
-    }
-
     try {
       await vscode.window.withProgress(
         {

--- a/src/test/SessionTabs.test.ts
+++ b/src/test/SessionTabs.test.ts
@@ -1,0 +1,143 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { JSDOM } from 'jsdom';
+
+import { SessionManager } from '../core/SessionManager';
+import { SessionUpdateHandler } from '../handlers/SessionUpdateHandler';
+import { ChatWebviewProvider } from '../ui/ChatWebviewProvider';
+
+function seededManager() {
+	const killed: string[] = [];
+	let created = 1;
+	const connection = {
+		newSession: async () => ({ sessionId: `session-${++created}` }),
+	};
+	const connectionManager = {
+		getConnection: (agentId: string) =>
+			agentId === 'agent-1' ? { connection, initResponse: {} } : undefined,
+		removeConnection: () => undefined,
+	} as any;
+	const agentManager = {
+		killAgent: (agentId: string) => killed.push(agentId),
+	} as any;
+
+	const manager = new SessionManager(agentManager, connectionManager, new SessionUpdateHandler());
+	const seed = {
+		sessionId: 'session-1',
+		agentId: 'agent-1',
+		agentName: 'Agent',
+		agentDisplayName: 'Agent',
+		cwd: '/tmp',
+		createdAt: new Date().toISOString(),
+		initResponse: {} as any,
+		modes: null,
+		models: null,
+		configOptions: null,
+		availableCommands: [],
+	};
+	(manager as any).sessions.set('session-1', seed);
+	(manager as any).agentSessions.set('Agent', 'session-1');
+	(manager as any).activeSessionId = 'session-1';
+
+	return { manager, killed };
+}
+
+suite('Live sessions', () => {
+	test('a new conversation leaves the running session alive', async () => {
+		const { manager, killed } = seededManager();
+
+		const created = await manager.newConversation();
+
+		assert.strictEqual(created?.sessionId, 'session-2');
+		assert.deepStrictEqual(killed, [], 'the agent process is not killed');
+		assert.strictEqual(manager.getActiveSessionId(), 'session-2');
+		assert.deepStrictEqual(
+			manager.listLiveSessions().map((session) => session.sessionId),
+			['session-1', 'session-2'],
+		);
+	});
+
+	test('switching back to a live session needs no replay from the agent', async () => {
+		const { manager } = seededManager();
+		await manager.newConversation();
+
+		const back = manager.activateSession('session-1');
+
+		assert.strictEqual(back?.sessionId, 'session-1');
+		assert.strictEqual(manager.getActiveSessionId(), 'session-1');
+		assert.strictEqual(manager.activateSession('session-404'), undefined);
+	});
+
+	test('disconnecting drops every session of that agent', async () => {
+		const { manager, killed } = seededManager();
+		await manager.newConversation();
+
+		await manager.disconnectAgent('Agent');
+
+		assert.deepStrictEqual(killed, ['agent-1']);
+		assert.deepStrictEqual(manager.listLiveSessions(), []);
+		assert.strictEqual(manager.getActiveSessionId(), null);
+	});
+});
+
+suite('Session tabs', () => {
+	test('renders one tab per session and reports the clicked one', () => {
+		const updateHandler = new SessionUpdateHandler();
+		const provider = new ChatWebviewProvider(
+			vscode.Uri.file('/tmp/acp-client-test'),
+			{} as any,
+			updateHandler,
+		);
+		const html = (provider as any).getHtmlContent({
+			cspSource: 'test-source',
+			asWebviewUri: (uri: vscode.Uri) => uri,
+		} as unknown as vscode.Webview) as string;
+		const posted: any[] = [];
+		const dom = new JSDOM(html, {
+			runScripts: 'dangerously',
+			beforeParse(window) {
+				(window as any).acquireVsCodeApi = () => ({
+					postMessage: (message: any) => posted.push(message),
+					getState: () => undefined,
+					setState: (next: unknown) => next,
+				});
+			},
+		});
+
+		try {
+			dom.window.dispatchEvent(
+				new dom.window.MessageEvent('message', {
+					data: {
+						type: 'sessions',
+						sessions: [
+							{ sessionId: 'session-1', label: 'Chat 1', agentName: 'Agent', active: false, busy: true },
+							{ sessionId: 'session-2', label: 'Chat 2', agentName: 'Agent', active: true, busy: false },
+						],
+					},
+				}),
+			);
+
+			const tabs = dom.window.document.querySelectorAll('.session-tab');
+			assert.strictEqual(tabs.length, 2);
+			assert.ok(tabs[1].classList.contains('active'), 'the second tab is on screen');
+			assert.strictEqual(tabs[0].querySelectorAll('.busy').length, 1, 'the running tab is marked');
+			assert.strictEqual(tabs[1].querySelectorAll('.busy').length, 0);
+
+			(tabs[1] as HTMLElement).click();
+			assert.strictEqual(
+				posted.filter((m) => m.type === 'selectSession').length,
+				0,
+				'clicking the visible tab does nothing',
+			);
+
+			(tabs[0] as HTMLElement).click();
+			assert.deepStrictEqual(JSON.parse(JSON.stringify(posted[posted.length - 1])), {
+				type: 'selectSession',
+				sessionId: 'session-1',
+			});
+		} finally {
+			dom.window.close();
+			provider.dispose();
+		}
+	});
+});

--- a/src/ui/ChatWebviewProvider.ts
+++ b/src/ui/ChatWebviewProvider.ts
@@ -6,6 +6,9 @@ import type { SessionNotification } from '@agentclientprotocol/sdk';
 import { logError } from '../utils/Logger';
 import { sendEvent } from '../utils/TelemetryManager';
 
+/** Session updates kept per session for tab switching. */
+const TRANSCRIPT_LIMIT = 5000;
+
 /**
  * WebviewViewProvider for the ACP chat sidebar.
  * Renders chat messages, tool calls, plans, and handles user input.
@@ -16,6 +19,10 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
   private view?: vscode.WebviewView;
   private updateListener: SessionUpdateListener;
   private _hasChatContent = false;
+  /** Session updates per session, replayed when the user switches tabs. */
+  private transcripts = new Map<string, SessionNotification[]>();
+  /** Prompts still running, per session. */
+  private inFlight = new Map<string, number>();
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -78,6 +85,9 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         case 'cancelTurn':
           await this.handleCancelTurn();
           break;
+        case 'selectSession':
+          this.handleSelectSession(message.sessionId);
+          break;
         case 'setMode':
           await this.handleSetMode(message.modeId);
           break;
@@ -95,6 +105,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
         case 'ready':
           // Webview loaded — send current session state
           this.sendCurrentState();
+          this.postSessions();
           break;
         case 'renderMarkdown': {
           // Webview requests markdown rendering for history items
@@ -144,6 +155,15 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       });
     }
 
+    // Every session keeps its own transcript so a tab that was left running
+    // can be replayed when the user comes back to it.
+    const transcript = this.transcripts.get(update.sessionId) ?? [];
+    transcript.push(update);
+    if (transcript.length > TRANSCRIPT_LIMIT) {
+      transcript.splice(0, transcript.length - TRANSCRIPT_LIMIT);
+    }
+    this.transcripts.set(update.sessionId, transcript);
+
     // Only forward to the webview if this is the active session — the
     // webview only ever shows one session at a time.
     const activeId = this.sessionManager.getActiveSessionId();
@@ -180,26 +200,90 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     this.sessionManager.recordFirstPrompt(activeId, text);
 
     // Tell webview we're processing
-    this.postMessage({ type: 'promptStart' });
+    this.inFlight.set(activeId, (this.inFlight.get(activeId) ?? 0) + 1);
+    this.postForSession(activeId, { type: 'promptStart' });
+    this.postSessions();
 
     try {
       const response = await this.sessionManager.sendPrompt(activeId, text);
+      this.sessionManager.touchHistory(activeId);
       // Render the accumulated assistant text as markdown
       // The webview will have sent us the raw text via promptEnd handling
-      this.postMessage({
+      this.finishPrompt(activeId, {
         type: 'promptEnd',
         stopReason: response.stopReason,
         usage: (response as any).usage,
       });
-      this.sessionManager.touchHistory(activeId);
     } catch (e: any) {
       logError('Prompt failed', e);
-      this.postMessage({
+      this.postForSession(activeId, {
         type: 'error',
         message: e.message || 'Prompt failed',
       });
-      this.postMessage({ type: 'promptEnd', stopReason: 'error' });
+      this.finishPrompt(activeId, { type: 'promptEnd', stopReason: 'error' });
     }
+  }
+
+  /** A prompt returned: only the session it belongs to leaves the busy state. */
+  private finishPrompt(sessionId: string, endMessage: Record<string, unknown>): void {
+    const left = (this.inFlight.get(sessionId) ?? 1) - 1;
+    if (left > 0) {
+      this.inFlight.set(sessionId, left);
+    } else {
+      this.inFlight.delete(sessionId);
+    }
+    this.postForSession(sessionId, endMessage);
+    this.postSessions();
+  }
+
+  /** Post a message only while the given session is the one on screen. */
+  private postForSession(sessionId: string, message: Record<string, unknown>): void {
+    if (this.sessionManager.getActiveSessionId() !== sessionId) { return; }
+    this.postMessage(message);
+  }
+
+  /**
+   * Send the tab strip: one entry per live session, marking which one is on
+   * screen and which ones are working.
+   */
+  postSessions(): void {
+    const live = this.sessionManager.listLiveSessions();
+    const liveIds = new Set(live.map((session) => session.sessionId));
+    for (const sessionId of this.transcripts.keys()) {
+      if (!liveIds.has(sessionId)) { this.transcripts.delete(sessionId); }
+    }
+    const activeId = this.sessionManager.getActiveSessionId();
+    this.postMessage({
+      type: 'sessions',
+      sessions: live.map((session, index) => ({
+        sessionId: session.sessionId,
+        label: session.title?.trim() || `Chat ${index + 1}`,
+        agentName: session.agentDisplayName,
+        active: session.sessionId === activeId,
+        busy: (this.inFlight.get(session.sessionId) ?? 0) > 0,
+      })),
+    });
+  }
+
+  /**
+   * Switch to a live session and repaint the chat from its buffered updates.
+   */
+  private handleSelectSession(sessionId: string): void {
+    const session = this.sessionManager.activateSession(sessionId);
+    if (!session) { return; }
+    this.postMessage({ type: 'loadSessionStart' });
+    for (const update of this.transcripts.get(sessionId) ?? []) {
+      this.postMessage({
+        type: 'sessionUpdate',
+        update: update.update,
+        sessionId: update.sessionId,
+      });
+    }
+    this.postMessage({ type: 'loadSessionEnd', ok: true });
+    if ((this.inFlight.get(sessionId) ?? 0) > 0) {
+      this.postMessage({ type: 'promptStart' });
+    }
+    this.postSessions();
   }
 
   /**
@@ -301,7 +385,12 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
    * Notify webview of a new active session.
    */
   notifyActiveSessionChanged(): void {
+    const activeId = this.sessionManager.getActiveSessionId();
+    if (activeId && !this.transcripts.get(activeId)?.length) {
+      this.clearChat();
+    }
     this.sendCurrentState();
+    this.postSessions();
   }
 
   /**
@@ -1117,9 +1206,62 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       opacity: 0.9;
     }
     .load-overlay .label { opacity: 0.85; }
+
+    .session-tabs {
+      display: none;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 6px 0;
+      overflow-x: auto;
+    }
+    .session-tabs.visible { display: flex; }
+    .session-tab {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      flex-shrink: 0;
+      max-width: 160px;
+      padding: 3px 8px;
+      border: 1px solid var(--vscode-panel-border);
+      border-radius: 4px 4px 0 0;
+      background: var(--vscode-editorWidget-background);
+      color: var(--vscode-foreground);
+      font-size: 0.85em;
+      font-family: inherit;
+      cursor: pointer;
+    }
+    .session-tab.active {
+      background: var(--vscode-tab-activeBackground, var(--vscode-editor-background));
+      border-bottom-color: transparent;
+    }
+    .session-tab .label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .session-tab .busy {
+      flex-shrink: 0;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--vscode-progressBar-background);
+    }
+    .session-tab-new {
+      flex-shrink: 0;
+      padding: 3px 8px;
+      border: 1px dashed var(--vscode-panel-border);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--vscode-descriptionForeground);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.85em;
+    }
   </style>
 </head>
 <body>
+  <div class="session-tabs" id="sessionTabs"></div>
+
   <div class="session-banner" id="sessionBanner">
     <span class="dot"></span>
     <div class="info">
@@ -1202,6 +1344,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     const sendStopBtn = document.getElementById('sendStopBtn');
     const statusEl = document.getElementById('status');
     const sessionBanner = document.getElementById('sessionBanner');
+    const sessionTabs = document.getElementById('sessionTabs');
     const bannerAgent = document.getElementById('bannerAgent');
     const bannerCwd = document.getElementById('bannerCwd');
     const inputArea = document.getElementById('inputArea');
@@ -1955,6 +2098,44 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
       return el;
     }
 
+    // One tab per live session. A session keeps running when another tab is
+    // in front, so the strip also shows which ones are busy.
+    function renderSessionTabs(sessions) {
+      if (!sessionTabs) return;
+      sessionTabs.innerHTML = '';
+      const items = Array.isArray(sessions) ? sessions : [];
+      if (!items.length) {
+        sessionTabs.classList.remove('visible');
+        return;
+      }
+      sessionTabs.classList.add('visible');
+      for (const item of items) {
+        const tab = document.createElement('button');
+        tab.className = 'session-tab' + (item.active ? ' active' : '');
+        tab.title = item.agentName ? item.agentName + ' — ' + item.label : item.label;
+        if (item.busy) {
+          const dot = document.createElement('span');
+          dot.className = 'busy';
+          tab.appendChild(dot);
+        }
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = item.label;
+        tab.appendChild(label);
+        tab.addEventListener('click', () => {
+          if (item.active) return;
+          vscode.postMessage({ type: 'selectSession', sessionId: item.sessionId });
+        });
+        sessionTabs.appendChild(tab);
+      }
+      const add = document.createElement('button');
+      add.className = 'session-tab-new';
+      add.textContent = '+';
+      add.title = 'New conversation';
+      add.addEventListener('click', () => execCmd('acp.newConversation'));
+      sessionTabs.appendChild(add);
+    }
+
     function hideEmpty() {
       if (emptyState) emptyState.style.display = 'none';
     }
@@ -2234,6 +2415,10 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
           } else {
             showNoSession();
           }
+          break;
+
+        case 'sessions':
+          renderSessionTabs(msg.sessions);
           break;
 
         case 'promptStart':


### PR DESCRIPTION
## Problem

`SessionManager.newConversation()` went through `disconnectAgent()`, which calls `killAgent()`. Starting another conversation therefore killed the agent process and spawned a fresh one, so whatever the agent was working on died with it. There was no way to let one conversation finish while starting another.

Nothing in ACP requires that. An agent keeps every session of a connection, and the protocol documents concurrent sessions per agent.

## Change

A new conversation now opens another session on the connection that is already there. The process is only replaced when the connection is actually gone.

The chat grew a tab strip above the banner: one tab per live session, a dot on the ones that are working, and a plus for another conversation. Switching repaints the chat from the session updates the client buffered for that session, capped at 5000 updates per session, so a tab that kept running shows what happened while it was in the background.

The prompt lifecycle is tracked per session, so a turn that ends in a background tab no longer clears the spinner of the tab on screen. Loading a stored session keeps live sessions instead of dropping them, and disconnecting an agent ends all of its sessions rather than only the one the pointer happened to hold.

The confirmation before a new conversation is gone together with the reason for it: nothing is discarded any more.

## Testing

`npm run lint`, `npm test` and `npm run package` pass locally on Linux. Four tests cover it: a new conversation leaves the running session alive and kills no process, switching back to a live session needs no replay from the agent, disconnecting drops every session of that agent, and the tab strip renders the busy and active state and reports the clicked session.

## Note on overlap

The test file brings its own JSDOM harness and adds jsdom to the dev dependencies, as #56 and #64 do. Whichever lands first, I am happy to rebase onto it and drop the duplicate harness.
