### PR TITLE
feat: continue the last session of the folder on connect

### DIFF
--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -217,6 +217,24 @@ export class SessionManager extends EventEmitter {
         throw e;
       }
 
+      this.capabilities.set(
+        agentName,
+        this.summarizeCapabilities(connInfo.initResponse.agentCapabilities),
+      );
+
+      // Pick up where the user left off in this folder instead of opening an
+      // empty session next to a history they would have to go looking for.
+      const restored = await this.restoreLatestSession(agentName, workspaceCwd);
+      if (restored) {
+        log(`Continued session ${restored.sessionId} for agent ${agentName}`);
+        sendEvent(
+          'agent/connect.end',
+          { agentName, result: 'success' },
+          { duration: Date.now() - connectStartTime },
+        );
+        return restored;
+      }
+
       // Create ACP session (with auth handling). The session is already
       // registered in `this.sessions` by createAcpSession so that any
       // notifications arriving during/after newSession can be persisted.
@@ -251,6 +269,36 @@ export class SessionManager extends EventEmitter {
     await this.disconnectAgent(agentName);
     this.emit('clear-chat');
     return this.connectToAgent(agentName);
+  }
+
+  /**
+   * Continue the agent's most recent session for this folder. Returns null
+   * when the agent cannot list or replay sessions, when it has none here, or
+   * when the attempt fails — the caller then starts a fresh session.
+   */
+  private async restoreLatestSession(
+    agentName: string,
+    cwd: string,
+  ): Promise<SessionInfo | null> {
+    const caps = this.capabilities.get(agentName);
+    if (!caps?.list || (!caps.load && !caps.resume)) {
+      return null;
+    }
+    try {
+      const { sessions } = await this.listSessions(agentName, { cwd });
+      const latest = [...(sessions ?? [])].sort(
+        (a, b) => Date.parse(b.updatedAt ?? '') - Date.parse(a.updatedAt ?? ''),
+      )[0];
+      if (!latest?.sessionId) {
+        return null;
+      }
+      return caps.load
+        ? await this.loadSession(agentName, latest.sessionId)
+        : await this.resumeSession(agentName, latest.sessionId);
+    } catch (e) {
+      logError(`Could not continue the last session for "${agentName}"`, e);
+      return null;
+    }
   }
 
   /**

--- a/src/test/ResumeLatest.test.ts
+++ b/src/test/ResumeLatest.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+
+import { SessionManager } from '../core/SessionManager';
+import { SessionUpdateHandler } from '../handlers/SessionUpdateHandler';
+
+function manager(): any {
+	return new SessionManager({} as any, {} as any, new SessionUpdateHandler()) as any;
+}
+
+suite('Continue the last session', () => {
+	test('resumes the most recently updated session of the folder', async () => {
+		const m = manager();
+		const asked: string[] = [];
+		m.capabilities.set('Agent', { list: true, load: false, resume: true });
+		m.listSessions = async (_agent: string, opts: { cwd?: string }) => {
+			asked.push(opts.cwd ?? '');
+			return {
+				sessions: [
+					{ sessionId: 'older', updatedAt: '2026-08-31T20:47:29Z' },
+					{ sessionId: 'newest', updatedAt: '2026-09-01T04:35:25Z' },
+				],
+			};
+		};
+		m.resumeSession = async (_agent: string, sessionId: string) => ({ sessionId });
+		m.loadSession = async () => assert.fail('load is not advertised');
+
+		const restored = await m.restoreLatestSession('Agent', '/work/project');
+
+		assert.strictEqual(restored.sessionId, 'newest');
+		assert.deepStrictEqual(asked, ['/work/project'], 'the folder is passed as the filter');
+	});
+
+	test('prefers load when the agent replays that way', async () => {
+		const m = manager();
+		m.capabilities.set('Agent', { list: true, load: true, resume: true });
+		m.listSessions = async () => ({ sessions: [{ sessionId: 'only', updatedAt: '2026-09-01T04:35:25Z' }] });
+		m.loadSession = async (_agent: string, sessionId: string) => ({ sessionId, via: 'load' });
+		m.resumeSession = async () => assert.fail('load wins over resume');
+
+		assert.strictEqual((await m.restoreLatestSession('Agent', '/work')).via, 'load');
+	});
+
+	test('starts fresh when the folder has no session, the agent cannot replay, or the call fails', async () => {
+		const empty = manager();
+		empty.capabilities.set('Agent', { list: true, load: false, resume: true });
+		empty.listSessions = async () => ({ sessions: [] });
+		assert.strictEqual(await empty.restoreLatestSession('Agent', '/work'), null);
+
+		const noReplay = manager();
+		noReplay.capabilities.set('Agent', { list: true, load: false, resume: false });
+		noReplay.listSessions = async () => assert.fail('nothing to replay into');
+		assert.strictEqual(await noReplay.restoreLatestSession('Agent', '/work'), null);
+
+		const broken = manager();
+		broken.capabilities.set('Agent', { list: true, load: false, resume: true });
+		broken.listSessions = async () => { throw new Error('agent said no'); };
+		assert.strictEqual(await broken.restoreLatestSession('Agent', '/work'), null);
+	});
+});


### PR DESCRIPTION
## Problem

Connecting to an agent always opened an empty session. The previous work sat behind the Agents view: connect, expand the agent, wait for the list to load, pick the session. Someone who does not know that path sees an empty chat and concludes the history is gone, which is what happened to me after a window reload.

The session list is also filtered by the workspace folder, which is the right behavior but makes an empty list ambiguous: it looks the same whether there is no history or whether the history belongs to another folder.

## Change

Connecting asks the agent for the sessions of the current folder and continues the most recent one, replaying it through `session/load` or `session/resume`, whichever the agent advertises. Load is preferred when both are available.

Every path that cannot produce a session falls back to the previous behavior of creating a fresh one: an agent without `session/list`, an agent that can neither load nor resume, a folder with no sessions, or a failure while listing. Agents that do none of this behave exactly as before.

## Testing

`npm run lint`, `npm test` and `npm run package` pass locally on Linux. Three tests cover the selection of the most recently updated session including the folder filter that is passed along, the preference for load when the agent advertises both, and the three fallbacks to a fresh session.

## Note

This pairs well with the session tabs PR, where an intentionally empty conversation is one click on the plus in the tab strip. It does not depend on it: without that PR, a new conversation is still reachable from the ACP: New Conversation command.
